### PR TITLE
Make LLM the default NLP backend, SpaCy and APIs optional

### DIFF
--- a/.claude/commands/langwich.md
+++ b/.claude/commands/langwich.md
@@ -1,4 +1,13 @@
-You are a friendly language learning assistant helping the user set up a personalised langwich worksheet. Guide them through a short interactive setup, then generate the worksheet using the `langwich` CLI.
+You are a friendly language learning assistant helping the user set up a personalised langwich worksheet. Guide them through a short interactive setup, then generate the worksheet.
+
+## How it works
+
+langwich has two modes for populating vocabulary:
+
+1. **LLM mode (default)** — You (the AI assistant) generate the vocabulary, translations, CEFR levels, and example phrases directly, write them as JSON, and feed them to `langwich --from-json`. No external APIs or SpaCy needed. This is the recommended path.
+2. **Mining mode (optional)** — Uses SpaCy + web sources (Wikipedia, arXiv, etc.) to mine vocabulary automatically. Requires `pip install langwich[mining]`.
+
+Default to LLM mode. Only suggest mining mode if the user explicitly asks for automated corpus mining or already has the extras installed.
 
 ## Step 1 — Mother tongue
 
@@ -62,27 +71,84 @@ Accept free-form descriptions ("I'm a total beginner", "intermediate") and map t
 Show a clear summary of what you collected:
 
 ```
-Mother tongue : <source_lang>
-Target language : <target_lang>
-Topics : <domain1>, <domain2>, …
-CEFR level : <level>
+Mother tongue  : <source_lang>
+Target language: <target_lang>
+Topics         : <domain1>, <domain2>, ...
+CEFR level     : <level>
 ```
 
 Ask the user to confirm ("Does this look right? Type yes to generate, or tell me what to change.").
 
-Once confirmed, generate the worksheet by running the CLI for each domain:
+Once confirmed, generate the worksheet for each domain using these steps:
+
+### Generate vocabulary JSON
+
+For each domain, create a JSON file at `./data/<domain>_<source>_<target>.json` with the following structure. Use your own language knowledge to generate high-quality, domain-relevant vocabulary and example phrases at the requested CEFR level:
+
+```json
+{
+  "domain": "<domain-slug>",
+  "source_lang": "<source_iso>",
+  "target_lang": "<target_iso>",
+  "vocabulary": [
+    {
+      "term": "platform",
+      "lemma": "platform",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["Bahnsteig", "Gleis"],
+      "frequency": 0.85
+    }
+  ],
+  "phrases": [
+    {
+      "text": "The train departs from platform 3.",
+      "translation": "Der Zug faehrt von Gleis 3 ab.",
+      "cefr": "A2"
+    }
+  ]
+}
+```
+
+Guidelines for generating vocabulary:
+- Include **20-30 vocabulary items** per domain, appropriate for the CEFR level.
+- Mix parts of speech: mostly nouns and verbs, some adjectives and adverbs.
+- Provide **1-3 translations** per term (the most common ones).
+- Include **15-20 example phrases** that use the vocabulary in natural sentences.
+- Every phrase must have a translation in the learner's native language.
+- Set `frequency` between 0.0 and 1.0 (higher = more common in the domain).
+- Terms and phrases should be genuinely useful for the domain, not generic filler.
+
+### Build the worksheet
+
+After writing the JSON, run:
 
 ```bash
-langwich --domain <domain-slug> \
-         --source-lang <source_iso> \
-         --target-lang <target_iso> \
+langwich --from-json ./data/<domain>_<source>_<target>.json \
          --level <CEFR> \
          --path balanced
 ```
 
-Use the ISO 639-1 two-letter code for `--source-lang` and `--target-lang` (e.g. `en`, `de`, `fr`, `es`, `ja`, `zh`, `pt`, `it`, `ar`, `ru`, `ko`).
-
 Report the path of every generated PDF to the user and suggest they open it with any PDF viewer.
+
+## Setup assistance
+
+If `langwich` is not installed yet, help the user set it up:
+
+```bash
+pip install -e .
+```
+
+That's it. The core installation needs only Python 3.11+ and four lightweight packages (reportlab, sqlalchemy, pydantic, pydantic-settings). No SpaCy download, no API keys, no `.env` file required for the default LLM mode.
+
+If the user wants the full mining pipeline (SpaCy + web source extraction), they can run:
+
+```bash
+pip install -e ".[mining]"
+python -m spacy download en_core_web_sm
+```
+
+Then use `langwich --domain <slug> --source-lang <code> --target-lang <code> --level <CEFR> --path balanced` instead of `--from-json`.
 
 ## Tone and style
 

--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,23 @@
-# scads.ai LLM API (OpenAI-compatible endpoint)
-SCADS_API_KEY=your-key-here
-SCADS_BASE_URL=https://llm.scads.ai/v1
-
-# SpaCy model (download with: python -m spacy download en_core_web_sm)
-SPACY_MODEL=en_core_web_sm
+# langwich configuration
+# ─────────────────────
+# Most settings are optional. The core (PDF generation from JSON) works
+# without any configuration at all.
 
 # Logging
 LOG_LEVEL=INFO
 
-# Mining defaults
-MINING_MAX_SOURCES=50
-MINING_MAX_PAGES_PER_SOURCE=10
-
-# PDF output
+# PDF output directory (default: ./output)
 PDF_OUTPUT_DIR=./output
+
+# ── Mining extras (only needed with: pip install langwich[mining]) ────
+
+# SpaCy model (download with: python -m spacy download en_core_web_sm)
+# SPACY_MODEL=en_core_web_sm
+
+# scads.ai LLM API — used for CEFR classification fallback during mining
+# SCADS_API_KEY=your-key-here
+# SCADS_BASE_URL=https://llm.scads.ai/v1
+
+# Mining pipeline tuning
+# MINING_MAX_SOURCES=50
+# MINING_MAX_PAGES_PER_SOURCE=10

--- a/README.md
+++ b/README.md
@@ -2,18 +2,96 @@
 
 **Automated language learning worksheet generator for e-paper devices and print.**
 
-langwich generates professional PDF worksheets for language learning. It uses a domain-specific vocabulary database, configurable learning paths, and a mining pipeline that builds vocabulary from open-access scientific and educational sources.
+langwich generates professional PDF worksheets for language learning. It supports domain-specific vocabulary, configurable learning paths, and 9 different exercise types — all rendered in a clean Cupertino-style design optimised for e-paper and print.
+
+---
+
+## Quick Start
+
+```bash
+pip install -e .
+```
+
+That's it. The core needs only Python 3.11+ and four packages: reportlab, sqlalchemy, pydantic, pydantic-settings. No SpaCy, no API keys, no `.env` file.
+
+### Using with Claude Code (recommended)
+
+Run the `/langwich` slash command. Claude walks you through picking your languages, topics, and level, then generates the vocabulary and worksheets for you automatically. Nothing else to install.
+
+### Using from the command line
+
+Provide vocabulary as a JSON file and generate a worksheet:
+
+```bash
+langwich --from-json vocab.json --level B1 --path balanced
+```
+
+The JSON format is simple — see [JSON Format](#json-format) below.
+
+---
+
+## Two Modes
+
+### 1. LLM Mode (default) — zero extra dependencies
+
+The AI assistant generates vocabulary, translations, CEFR levels, and example phrases directly, writes them as JSON, and feeds them to `langwich --from-json`. This is the fastest path from zero to worksheet.
+
+### 2. Mining Mode (optional) — automated corpus extraction
+
+Uses SpaCy + web sources (Wikipedia, arXiv, OpenAlex, YouTube) to mine domain-specific vocabulary automatically.
+
+```bash
+# Install mining extras
+pip install -e ".[mining]"
+python -m spacy download en_core_web_sm
+
+# Mine and generate
+langwich --domain railway-operations --source-lang en --target-lang de --level B1 --path balanced
+```
 
 ---
 
 ## Features
 
-- **Domain-specific vocabulary**: Separate SQLite databases per domain+language combo (railway operations, medicine, space exploration, etc.)
-- **Open-access mining**: Pulls vocabulary from Wikipedia, arXiv, OpenAlex, YouTube transcripts, and more
-- **CEFR classification**: Rule-based level tagging (A1–C2) with LLM fallback via scads.ai
-- **Configurable learning paths**: Define exercise sequences — Vocabulary Focus, Reading First, Balanced, Production, Multimedia
+- **Domain-specific vocabulary**: Separate SQLite databases per domain+language combo
 - **9 exercise types**: Vocab matching, fill-in-the-blanks, synonyms, translation, reading comprehension, creative writing, text summary, YouTube tasks, drawing tasks
-- **Cupertino-style PDFs**: Clean, modern design optimised for e-paper legibility and print
+- **5 learning paths**: Vocabulary Focus, Reading First, Balanced, Production, Multimedia
+- **CEFR levels**: A1 through C2, with level-appropriate content selection
+- **Cupertino-style PDFs**: Clean Helvetica typography, high contrast, e-paper optimised
+- **Optional mining pipeline**: SpaCy NLP + open-access sources for automated vocabulary extraction
+
+---
+
+## JSON Format
+
+The `--from-json` input uses this structure:
+
+```json
+{
+  "domain": "railway-operations",
+  "source_lang": "en",
+  "target_lang": "de",
+  "vocabulary": [
+    {
+      "term": "platform",
+      "lemma": "platform",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["Bahnsteig", "Gleis"],
+      "frequency": 0.85
+    }
+  ],
+  "phrases": [
+    {
+      "text": "The train departs from platform 3.",
+      "translation": "Der Zug faehrt von Gleis 3 ab.",
+      "cefr": "A2"
+    }
+  ]
+}
+```
+
+Fields: `term` (required), `lemma` (defaults to lowercase term), `pos` (NOUN/VERB/ADJ/ADV/OTHER), `cefr` (A1-C2), `translations` (list of strings), `frequency` (0.0-1.0).
 
 ---
 
@@ -144,7 +222,15 @@ classDiagram
 
 ```mermaid
 flowchart TB
-    subgraph MINING["Mining Pipeline"]
+    subgraph LLM_MODE["LLM Mode (default)"]
+        direction TB
+        L1([AI generates vocabulary + phrases])
+        L2[Write JSON file]
+        L3[(Import into SQLite DB)]
+        L1 --> L2 --> L3
+    end
+
+    subgraph MINING["Mining Mode (optional)"]
         direction TB
         M1([User provides domain + languages])
         M2[Source Discovery<br/>Wikipedia, arXiv, OpenAlex, YouTube]
@@ -170,7 +256,7 @@ flowchart TB
 
     subgraph GENERATION["Worksheet Generation"]
         direction TB
-        G1([User selects domain + path + level])
+        G1([Select path + level])
         G2[Load vocabulary + phrases<br/>from SQLite by CEFR level]
         G3[Iterate LearningPath steps]
         G4[Instantiate Exercise class<br/>from registry]
@@ -182,132 +268,34 @@ flowchart TB
         G1 --> G2 --> G3 --> G4 --> G5 --> G6 --> G7 --> G8
     end
 
+    L3 -.->|vocabulary + phrases| G2
     M13 -.->|vocabulary + phrases| G2
 
+    style LLM_MODE fill:#f0fff0,stroke:#34a853,stroke-width:2px
     style MINING fill:#f0f7ff,stroke:#0071E3,stroke-width:2px
-    style GENERATION fill:#f0fff0,stroke:#34a853,stroke-width:2px
+    style GENERATION fill:#fff8f0,stroke:#ea8600,stroke-width:2px
 ```
 
 ---
 
 ## Tech Stack
 
-| Component | Technology |
-|-----------|------------|
-| Language | Python 3.11+ |
-| Database | SQLite via SQLAlchemy 2.0 |
-| NLP | SpaCy 3.7 |
-| PDF Rendering | ReportLab 4.1 |
-| LLM Fallback | scads.ai (OpenAI-compatible API) |
-| HTTP Client | httpx |
-| Configuration | Pydantic Settings |
-| YouTube | youtube-transcript-api |
-| Parsing | BeautifulSoup4, lxml, feedparser |
+| Component | Package | Required |
+|-----------|---------|----------|
+| PDF Rendering | ReportLab 4.1 | Core |
+| Database | SQLAlchemy 2.0 (SQLite) | Core |
+| Configuration | Pydantic Settings | Core |
+| NLP | SpaCy 3.7 | Mining extra |
+| LLM Fallback | scads.ai (OpenAI-compatible) | Mining extra |
+| HTTP Client | httpx | Mining extra |
+| YouTube | youtube-transcript-api | Mining extra |
+| Parsing | BeautifulSoup4, lxml, feedparser | Mining extra |
 
 ---
 
-## Setup
+## Configuration
 
-### Prerequisites
-
-- Python 3.11 or later
-- A SpaCy language model (downloaded automatically on first run)
-- (Optional) A scads.ai API key for LLM-based CEFR classification fallback
-
-### Installation
-
-```bash
-# Clone the repository
-git clone https://github.com/your-org/langwich.git
-cd langwich
-
-# Create a virtual environment
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-
-# Install dependencies
-pip install -e .
-
-# Or install from requirements.txt
-pip install -r requirements.txt
-
-# Download SpaCy model
-python -m spacy download en_core_web_sm
-
-# Copy and configure environment variables
-cp .env.example .env
-# Edit .env with your scads.ai API key
-```
-
----
-
-## Usage
-
-### 1. Mine vocabulary for a domain
-
-```python
-import asyncio
-from langwich.db.manager import DomainDatabase
-from langwich.mining.pipeline import MiningPipeline
-from langwich.mining.sources import WikipediaSource, ArxivSource
-
-# Create a domain database
-db = DomainDatabase(domain="railway-operations", source_lang="en", target_lang="de")
-db.initialize()
-
-# Set up sources and run the mining pipeline
-sources = [WikipediaSource(), ArxivSource()]
-pipeline = MiningPipeline(db=db, sources=sources)
-result = asyncio.run(pipeline.run())
-
-print(f"Mined {result.terms_added} terms and {result.phrases_added} phrases")
-```
-
-### 2. Generate a worksheet
-
-```python
-from langwich.db.manager import DomainDatabase
-from langwich.db.models import CEFRLevel
-from langwich.generator import WorksheetGenerator
-from langwich.paths.defaults import BUILTIN_PATHS
-
-# Open an existing domain database
-db = DomainDatabase(domain="railway-operations", source_lang="en", target_lang="de")
-db.initialize()
-
-# Generate a worksheet
-generator = WorksheetGenerator(
-    db=db,
-    path=BUILTIN_PATHS["balanced"],
-    level=CEFRLevel.B1,
-)
-pdf_path = generator.generate()
-print(f"Worksheet saved to: {pdf_path}")
-```
-
-### 3. CLI usage
-
-```bash
-# Generate a worksheet from the command line
-langwich --domain railway-operations --source-lang en --target-lang de --level B1 --path balanced
-```
-
-### 4. Custom learning path
-
-```python
-from langwich.paths.template import LearningPath, PathStep, ExerciseType
-
-custom_path = LearningPath(
-    name="My Custom Path",
-    description="Vocab + Reading + Writing",
-    steps=[
-        PathStep(ExerciseType.VOCAB_MATCHING, "Key Terms", required=True),
-        PathStep(ExerciseType.READING_COMPREHENSION, "Read & Understand"),
-        PathStep(ExerciseType.CREATIVE_WRITING, "Express Yourself",
-                 config={"num_vocab_to_use": 8, "line_count": 12}),
-    ],
-)
-```
+Copy `.env.example` to `.env` if you need to change defaults. For the core LLM mode, no configuration is required.
 
 ---
 
@@ -317,7 +305,7 @@ custom_path = LearningPath(
 langwich/
 ├── README.md
 ├── pyproject.toml
-├── requirements.txt
+├── requirements.txt              # Core deps only
 ├── .env.example
 ├── docs/
 │   ├── architecture.md
@@ -327,15 +315,16 @@ langwich/
 │   └── langwich/
 │       ├── __init__.py
 │       ├── config.py
-│       ├── generator.py
+│       ├── generator.py          # CLI entry point + WorksheetGenerator
+│       ├── import_data.py        # JSON vocabulary import (LLM mode)
 │       ├── db/
-│       │   ├── models.py          # SQLAlchemy ORM models
-│       │   └── manager.py         # Per-domain DB manager
-│       ├── mining/
-│       │   ├── pipeline.py        # 7-stage mining orchestrator
+│       │   ├── models.py         # SQLAlchemy ORM models
+│       │   └── manager.py        # Per-domain DB manager
+│       ├── mining/               # Optional — pip install langwich[mining]
+│       │   ├── pipeline.py
 │       │   ├── domain_tagger.py
 │       │   ├── sources/
-│       │   │   ├── base.py        # Abstract Source class
+│       │   │   ├── base.py
 │       │   │   ├── wikipedia.py
 │       │   │   ├── arxiv.py
 │       │   │   ├── openalex.py
@@ -345,10 +334,10 @@ langwich/
 │       │       ├── phrase_extractor.py
 │       │       └── cefr_classifier.py
 │       ├── paths/
-│       │   ├── template.py        # LearningPath, PathStep
-│       │   └── defaults.py        # 5 built-in path templates
+│       │   ├── template.py       # LearningPath, PathStep
+│       │   └── defaults.py       # 5 built-in path templates
 │       ├── exercises/
-│       │   ├── base.py            # Abstract Exercise class
+│       │   ├── base.py           # Abstract Exercise class
 │       │   ├── vocab_matching.py
 │       │   ├── fill_blanks.py
 │       │   ├── synonyms.py
@@ -359,9 +348,9 @@ langwich/
 │       │   ├── youtube_task.py
 │       │   └── drawing_task.py
 │       └── rendering/
-│           ├── pdf_renderer.py    # Cupertino-style PDF engine
-│           ├── styles.py          # Typography + colours
-│           └── components.py      # Reusable PDF components
+│           ├── pdf_renderer.py   # Cupertino-style PDF engine
+│           ├── styles.py         # Typography + colours
+│           └── components.py     # Reusable PDF components
 ├── scripts/
 │   └── render_diagrams.py
 └── tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,14 @@ classifiers = [
 dependencies = [
     "reportlab>=4.1",
     "sqlalchemy>=2.0",
-    "spacy>=3.7",
-    "httpx>=0.27",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",
+]
+
+[project.optional-dependencies]
+mining = [
+    "spacy>=3.7",
+    "httpx>=0.27",
     "openai>=1.12",
     "youtube-transcript-api>=0.6",
     "beautifulsoup4>=4.12",
@@ -33,8 +37,7 @@ dependencies = [
     "feedparser>=6.0",
     "nltk>=3.8",
 ]
-
-[project.optional-dependencies]
+all = ["langwich[mining]"]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=4.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
+# Core dependencies (worksheet generation + PDF rendering)
 reportlab>=4.1
 sqlalchemy>=2.0
-spacy>=3.7
-httpx>=0.27
 pydantic>=2.6
 pydantic-settings>=2.2
-openai>=1.12
-youtube-transcript-api>=0.6
-beautifulsoup4>=4.12
-lxml>=5.1
-feedparser>=6.0
-nltk>=3.8

--- a/src/langwich/config.py
+++ b/src/langwich/config.py
@@ -61,12 +61,24 @@ class AppConfig(BaseSettings):
         extra="ignore",
     )
 
-    spacy_model: str = Field(default="en_core_web_sm")
+    spacy_model: str = Field(
+        default="en_core_web_sm",
+        description="SpaCy model name (only needed with pip install langwich[mining])",
+    )
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
 
     scads: ScadsConfig = Field(default_factory=ScadsConfig)
     mining: MiningConfig = Field(default_factory=MiningConfig)
     pdf: PDFConfig = Field(default_factory=PDFConfig)
+
+    @staticmethod
+    def has_mining_extras() -> bool:
+        """Check whether the optional mining dependencies are installed."""
+        try:
+            import spacy  # noqa: F401
+            return True
+        except ImportError:
+            return False
 
 
 # Module-level singleton — import and use directly.

--- a/src/langwich/generator.py
+++ b/src/langwich/generator.py
@@ -143,26 +143,67 @@ class WorksheetGenerator:
 
 
 def main() -> None:
-    """CLI entry point for quick worksheet generation."""
+    """CLI entry point for worksheet generation.
+
+    Supports two modes:
+      1. ``--from-json <file>`` — import LLM-generated vocabulary from JSON, then render.
+      2. ``--domain <name>``   — use an existing database (requires prior mining or import).
+    """
     import argparse
 
     from langwich.paths.defaults import BUILTIN_PATHS
 
-    parser = argparse.ArgumentParser(description="Generate a language learning worksheet")
-    parser.add_argument("--domain", required=True, help="Knowledge domain (e.g. railway-operations)")
-    parser.add_argument("--source-lang", default="en", help="Source language code")
-    parser.add_argument("--target-lang", default="de", help="Target language code")
-    parser.add_argument("--level", default="B1", choices=["A1", "A2", "B1", "B2", "C1", "C2"])
-    parser.add_argument("--path", default="balanced", choices=list(BUILTIN_PATHS.keys()))
-    parser.add_argument("--output", help="Output PDF path")
+    parser = argparse.ArgumentParser(
+        description="Generate a language learning worksheet",
+        epilog=(
+            "Quick start:  langwich --from-json vocab.json\n"
+            "With mining:  pip install langwich[mining]  then use --domain"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    # ── Input mode ──────────────────────────────────────────────────
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument(
+        "--from-json",
+        metavar="FILE",
+        help="Path to a JSON file with vocabulary and phrases (LLM-generated)",
+    )
+    input_group.add_argument(
+        "--domain",
+        help="Knowledge domain slug (uses existing database in ./data/)",
+    )
+
+    # ── Common options ──────────────────────────────────────────────
+    parser.add_argument("--source-lang", default="en", help="Source language ISO code (default: en)")
+    parser.add_argument("--target-lang", default="de", help="Target language ISO code (default: de)")
+    parser.add_argument(
+        "--level", default="B1",
+        choices=["A1", "A2", "B1", "B2", "C1", "C2"],
+        help="CEFR proficiency level (default: B1)",
+    )
+    parser.add_argument(
+        "--path", default="balanced",
+        choices=list(BUILTIN_PATHS.keys()),
+        help="Learning path template (default: balanced)",
+    )
+    parser.add_argument("--output", help="Output PDF path (auto-generated if omitted)")
+
     args = parser.parse_args()
 
-    db = DomainDatabase(
-        domain=args.domain,
-        source_lang=args.source_lang,
-        target_lang=args.target_lang,
-    )
-    db.initialize()
+    # ── Resolve database ────────────────────────────────────────────
+    if args.from_json:
+        from langwich.import_data import import_json_file
+
+        db = import_json_file(args.from_json)
+        print(f"Imported vocabulary from {args.from_json}")
+    else:
+        db = DomainDatabase(
+            domain=args.domain,
+            source_lang=args.source_lang,
+            target_lang=args.target_lang,
+        )
+        db.initialize()
 
     learning_path = BUILTIN_PATHS[args.path]
     level = CEFRLevel(args.level)

--- a/src/langwich/import_data.py
+++ b/src/langwich/import_data.py
@@ -1,0 +1,148 @@
+"""Import vocabulary and phrases from JSON — the LLM-friendly data path.
+
+When langwich is used via an AI assistant (e.g. Claude Code), the LLM itself
+acts as the NLP engine: it generates domain-relevant vocabulary, translations,
+CEFR levels, and example phrases directly.  This module imports that structured
+data into the per-domain SQLite database so the worksheet generator can use it.
+
+Expected JSON format
+────────────────────
+{
+  "domain": "railway-operations",
+  "source_lang": "en",
+  "target_lang": "de",
+  "vocabulary": [
+    {
+      "term": "platform",
+      "lemma": "platform",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["Bahnsteig", "Gleis"],
+      "frequency": 0.85
+    }
+  ],
+  "phrases": [
+    {
+      "text": "The train departs from platform 3.",
+      "translation": "Der Zug fährt von Gleis 3 ab.",
+      "cefr": "A2"
+    }
+  ]
+}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from langwich.db.manager import DomainDatabase
+from langwich.db.models import CEFRLevel, ClassificationMethod, PartOfSpeech
+
+logger = logging.getLogger(__name__)
+
+# Map short POS strings to the enum
+_POS_MAP: dict[str, PartOfSpeech] = {
+    "NOUN": PartOfSpeech.NOUN,
+    "VERB": PartOfSpeech.VERB,
+    "ADJ": PartOfSpeech.ADJECTIVE,
+    "ADJECTIVE": PartOfSpeech.ADJECTIVE,
+    "ADV": PartOfSpeech.ADVERB,
+    "ADVERB": PartOfSpeech.ADVERB,
+    "PREP": PartOfSpeech.PREPOSITION,
+    "PREPOSITION": PartOfSpeech.PREPOSITION,
+    "CONJ": PartOfSpeech.CONJUNCTION,
+    "CONJUNCTION": PartOfSpeech.CONJUNCTION,
+    "PRON": PartOfSpeech.PRONOUN,
+    "PRONOUN": PartOfSpeech.PRONOUN,
+    "DET": PartOfSpeech.DETERMINER,
+    "DETERMINER": PartOfSpeech.DETERMINER,
+    "INTJ": PartOfSpeech.INTERJECTION,
+    "NUM": PartOfSpeech.NUMERAL,
+    "PART": PartOfSpeech.PARTICLE,
+    "OTHER": PartOfSpeech.OTHER,
+}
+
+_CEFR_MAP: dict[str, CEFRLevel] = {v.value: v for v in CEFRLevel}
+
+
+def _parse_pos(raw: str) -> PartOfSpeech:
+    return _POS_MAP.get(raw.upper(), PartOfSpeech.OTHER)
+
+
+def _parse_cefr(raw: str) -> CEFRLevel:
+    return _CEFR_MAP.get(raw.upper(), CEFRLevel.UNKNOWN)
+
+
+def import_json(
+    data: dict[str, Any],
+    db_dir: Path | str = Path("./data"),
+) -> DomainDatabase:
+    """Import vocabulary and phrases from a JSON dict into a domain database.
+
+    Parameters
+    ----------
+    data : dict
+        JSON-compatible dict matching the schema described in this module's
+        docstring.
+    db_dir : Path | str
+        Directory for SQLite files.
+
+    Returns
+    -------
+    DomainDatabase
+        The initialised and populated database.
+    """
+    domain = data["domain"]
+    source_lang = data.get("source_lang", "en")
+    target_lang = data.get("target_lang", "de")
+
+    db = DomainDatabase(
+        domain=domain,
+        source_lang=source_lang,
+        target_lang=target_lang,
+        db_dir=db_dir,
+    )
+    db.initialize()
+
+    vocab_count = 0
+    for item in data.get("vocabulary", []):
+        db.add_vocabulary(
+            term=item["term"],
+            lemma=item.get("lemma", item["term"].lower()),
+            pos=_parse_pos(item.get("pos", "OTHER")),
+            level=_parse_cefr(item.get("cefr", "UNKNOWN")),
+            method=ClassificationMethod.LLM_FALLBACK,
+            frequency=item.get("frequency", 0.5),
+            translations=item.get("translations"),
+        )
+        vocab_count += 1
+
+    phrase_count = 0
+    for item in data.get("phrases", []):
+        db.add_phrase(
+            text=item["text"],
+            translation=item.get("translation"),
+            level=_parse_cefr(item.get("cefr", "UNKNOWN")),
+            method=ClassificationMethod.LLM_FALLBACK,
+        )
+        phrase_count += 1
+
+    logger.info(
+        "Imported %d vocabulary + %d phrases into %s",
+        vocab_count, phrase_count, db.db_path,
+    )
+    return db
+
+
+def import_json_file(
+    path: Path | str,
+    db_dir: Path | str = Path("./data"),
+) -> DomainDatabase:
+    """Load a JSON file and import it. Convenience wrapper around ``import_json``."""
+    path = Path(path)
+    with open(path) as f:
+        data = json.load(f)
+    return import_json(data, db_dir=db_dir)

--- a/src/langwich/mining/__init__.py
+++ b/src/langwich/mining/__init__.py
@@ -1,5 +1,13 @@
-"""Mining pipeline — discover, extract, and classify vocabulary from open-access sources."""
+"""Mining pipeline — discover, extract, and classify vocabulary from open-access sources.
 
-from langwich.mining.pipeline import MiningPipeline
+Requires the ``mining`` extra:  pip install langwich[mining]
+"""
 
-__all__ = ["MiningPipeline"]
+try:
+    from langwich.mining.pipeline import MiningPipeline
+
+    __all__ = ["MiningPipeline"]
+except ImportError:
+    # Mining extras (spacy, httpx, etc.) not installed — that's fine.
+    # The core worksheet generator works without them via JSON import.
+    __all__: list[str] = []


### PR DESCRIPTION
The core installation now needs only 4 packages (reportlab, sqlalchemy,
pydantic, pydantic-settings). SpaCy, httpx, and all mining dependencies
move to `pip install langwich[mining]`.

New default flow: the executing LLM generates vocabulary as JSON, which
is imported via `langwich --from-json` and rendered to PDF. No SpaCy
download, no API keys, no .env file required.

- Add import_data.py for JSON vocabulary/phrase import
- Add --from-json CLI flag as primary input mode
- Move mining deps to optional [mining] extra in pyproject.toml
- Guard mining __init__.py against missing optional imports
- Update /langwich skill to generate vocab directly as JSON
- Update README with two-mode architecture (LLM vs Mining)
- Simplify .env.example (most settings now optional)

https://claude.ai/code/session_01CAQG8f4nHWZgmVFeKKWhr4