### PR TITLE
Add task size constraints: half, full, and double page exercises

### DIFF
--- a/src/langwich/generator.py
+++ b/src/langwich/generator.py
@@ -27,7 +27,7 @@ from langwich.exercises.creative_writing import CreativeWritingExercise
 from langwich.exercises.text_summary import TextSummaryExercise
 from langwich.exercises.youtube_task import YouTubeTaskExercise
 from langwich.exercises.drawing_task import DrawingTaskExercise
-from langwich.paths.template import ExerciseType, LearningPath
+from langwich.paths.template import ExerciseType, LearningPath, TaskSize
 from langwich.rendering.components import grammar_reference_page, vocab_reference_page
 from langwich.rendering.pdf_renderer import PDFRenderer
 
@@ -105,6 +105,7 @@ class WorksheetGenerator:
             Path to the generated PDF file.
         """
         self.path.ensure_vocab_first()
+        self.path.validate_half_pairing()
 
         # Load vocabulary and phrases from the database
         vocabulary = self.db.query_vocabulary(level=self.level, limit=100)
@@ -117,6 +118,8 @@ class WorksheetGenerator:
 
         # Vocabulary reference page (opt-out with include_vocab_page=False)
         all_flowables: list[list[Any]] = []
+        all_sizes: list[TaskSize | None] = []
+
         if self.include_vocab_page and vocabulary:
             vocab_flowables = vocab_reference_page(
                 vocabulary,
@@ -124,6 +127,7 @@ class WorksheetGenerator:
                 target_lang=self.db.target_lang,
             )
             all_flowables.append(vocab_flowables)
+            all_sizes.append(None)  # reference pages use free-flow layout
 
         # Grammar reference page (opt-out with include_grammar_page=False)
         if self.include_grammar_page:
@@ -136,6 +140,7 @@ class WorksheetGenerator:
                 content=content,
             )
             all_flowables.append(grammar_flowables)
+            all_sizes.append(None)
 
         # Generate content for each exercise step
         for step in self.path.steps:
@@ -149,6 +154,7 @@ class WorksheetGenerator:
                 content = exercise.generate(vocabulary, phrases, self.level)
                 flowables = exercise.render(content)
                 all_flowables.append(flowables)
+                all_sizes.append(step.resolved_size)
             except Exception as exc:
                 logger.error("Exercise %s failed: %s", step.exercise_type, exc)
 
@@ -167,6 +173,7 @@ class WorksheetGenerator:
             domain=self.db.domain,
             level=self.level,
             worksheet_date=worksheet_date,
+            exercise_sizes=all_sizes,
         )
 
 

--- a/src/langwich/paths/defaults.py
+++ b/src/langwich/paths/defaults.py
@@ -7,16 +7,17 @@ Each path defines a different pedagogical approach:
 - **Production**: Emphasises writing and creative output
 """
 
-from langwich.paths.template import ExerciseType, LearningPath, PathStep
+from langwich.paths.template import ExerciseType, LearningPath, PathStep, TaskSize
 
 VOCABULARY_FOCUS = LearningPath(
     name="Vocabulary Focus",
     description="Term-heavy path: matching, synonyms, fill-in-the-blanks, translation.",
     steps=[
         PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
-        PathStep(ExerciseType.SYNONYMS, "Synonyms & Antonyms"),
-        PathStep(ExerciseType.FILL_BLANKS, "Fill in the Blanks"),
-        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),
+        PathStep(ExerciseType.SYNONYMS, "Synonyms & Antonyms"),       # half
+        PathStep(ExerciseType.FILL_BLANKS, "Fill in the Blanks"),      # half (pair)
+        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),    # half
+        PathStep(ExerciseType.DRAWING_TASK, "Visual Vocabulary"),      # half (pair)
     ],
 )
 
@@ -26,8 +27,8 @@ READING_FIRST = LearningPath(
     steps=[
         PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
         PathStep(ExerciseType.READING_COMPREHENSION, "Reading Passage"),
-        PathStep(ExerciseType.FILL_BLANKS, "Vocabulary in Context"),
-        PathStep(ExerciseType.TEXT_SUMMARY, "Summarise the Text"),
+        PathStep(ExerciseType.FILL_BLANKS, "Vocabulary in Context"),   # half
+        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),    # half (pair)
     ],
 )
 
@@ -37,8 +38,8 @@ BALANCED = LearningPath(
     steps=[
         PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
         PathStep(ExerciseType.READING_COMPREHENSION, "Reading Passage"),
-        PathStep(ExerciseType.FILL_BLANKS, "Fill in the Blanks"),
-        PathStep(ExerciseType.SYNONYMS, "Word Relationships"),
+        PathStep(ExerciseType.FILL_BLANKS, "Fill in the Blanks"),      # half
+        PathStep(ExerciseType.SYNONYMS, "Word Relationships"),         # half (pair)
         PathStep(ExerciseType.CREATIVE_WRITING, "Free Writing"),
     ],
 )
@@ -50,7 +51,8 @@ PRODUCTION = LearningPath(
         PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
         PathStep(ExerciseType.CREATIVE_WRITING, "Creative Writing"),
         PathStep(ExerciseType.TEXT_SUMMARY, "Text Summary"),
-        PathStep(ExerciseType.DRAWING_TASK, "Visual Response"),
+        PathStep(ExerciseType.DRAWING_TASK, "Visual Response"),        # half
+        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),    # half (pair)
     ],
 )
 
@@ -60,7 +62,8 @@ MULTIMEDIA = LearningPath(
     steps=[
         PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
         PathStep(ExerciseType.YOUTUBE_TASK, "Video Comprehension"),
-        PathStep(ExerciseType.FILL_BLANKS, "Key Terms"),
+        PathStep(ExerciseType.FILL_BLANKS, "Key Terms"),               # half
+        PathStep(ExerciseType.DRAWING_TASK, "Visual Response"),        # half (pair)
         PathStep(ExerciseType.CREATIVE_WRITING, "Reflection"),
     ],
 )

--- a/src/langwich/paths/defaults.py
+++ b/src/langwich/paths/defaults.py
@@ -13,11 +13,10 @@ VOCABULARY_FOCUS = LearningPath(
     name="Vocabulary Focus",
     description="Term-heavy path: matching, synonyms, fill-in-the-blanks, translation.",
     steps=[
-        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
-        PathStep(ExerciseType.SYNONYMS, "Synonyms & Antonyms"),       # half
-        PathStep(ExerciseType.FILL_BLANKS, "Fill in the Blanks"),      # half (pair)
-        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),    # half
-        PathStep(ExerciseType.DRAWING_TASK, "Visual Vocabulary"),      # half (pair)
+        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),  # half
+        PathStep(ExerciseType.SYNONYMS, "Synonyms & Antonyms"),                  # half (pair)
+        PathStep(ExerciseType.FILL_BLANKS, "Fill in the Blanks"),                # half
+        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),              # half (pair)
     ],
 )
 
@@ -25,10 +24,11 @@ READING_FIRST = LearningPath(
     name="Reading First",
     description="Comprehension-led path: read a text, then work on vocabulary.",
     steps=[
-        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
-        PathStep(ExerciseType.READING_COMPREHENSION, "Reading Passage"),
-        PathStep(ExerciseType.FILL_BLANKS, "Vocabulary in Context"),   # half
-        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),    # half (pair)
+        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),  # half
+        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),              # half (pair)
+        PathStep(ExerciseType.READING_COMPREHENSION, "Reading Passage"),         # double
+        PathStep(ExerciseType.FILL_BLANKS, "Vocabulary in Context"),             # half
+        PathStep(ExerciseType.SYNONYMS, "Word Relationships"),                   # half (pair)
     ],
 )
 
@@ -36,11 +36,12 @@ BALANCED = LearningPath(
     name="Balanced",
     description="A well-rounded mix of receptive and productive exercises.",
     steps=[
-        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
-        PathStep(ExerciseType.READING_COMPREHENSION, "Reading Passage"),
-        PathStep(ExerciseType.FILL_BLANKS, "Fill in the Blanks"),      # half
-        PathStep(ExerciseType.SYNONYMS, "Word Relationships"),         # half (pair)
-        PathStep(ExerciseType.CREATIVE_WRITING, "Free Writing"),
+        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),  # half
+        PathStep(ExerciseType.SYNONYMS, "Word Relationships"),                   # half (pair)
+        PathStep(ExerciseType.READING_COMPREHENSION, "Reading Passage"),         # double
+        PathStep(ExerciseType.FILL_BLANKS, "Fill in the Blanks"),                # half
+        PathStep(ExerciseType.DRAWING_TASK, "Visual Response"),                  # half (pair)
+        PathStep(ExerciseType.CREATIVE_WRITING, "Free Writing"),                 # full
     ],
 )
 
@@ -48,11 +49,12 @@ PRODUCTION = LearningPath(
     name="Production",
     description="Output-focused path: creative writing, summaries, drawing.",
     steps=[
-        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
-        PathStep(ExerciseType.CREATIVE_WRITING, "Creative Writing"),
-        PathStep(ExerciseType.TEXT_SUMMARY, "Text Summary"),
-        PathStep(ExerciseType.DRAWING_TASK, "Visual Response"),        # half
-        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),    # half (pair)
+        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),  # half
+        PathStep(ExerciseType.DRAWING_TASK, "Visual Response"),                  # half (pair)
+        PathStep(ExerciseType.CREATIVE_WRITING, "Creative Writing"),             # full
+        PathStep(ExerciseType.TEXT_SUMMARY, "Text Summary"),                     # full
+        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),              # half
+        PathStep(ExerciseType.SYNONYMS, "Word Relationships"),                   # half (pair)
     ],
 )
 
@@ -60,11 +62,12 @@ MULTIMEDIA = LearningPath(
     name="Multimedia",
     description="Incorporates YouTube tasks and varied media.",
     steps=[
-        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),
-        PathStep(ExerciseType.YOUTUBE_TASK, "Video Comprehension"),
-        PathStep(ExerciseType.FILL_BLANKS, "Key Terms"),               # half
-        PathStep(ExerciseType.DRAWING_TASK, "Visual Response"),        # half (pair)
-        PathStep(ExerciseType.CREATIVE_WRITING, "Reflection"),
+        PathStep(ExerciseType.VOCAB_MATCHING, "Key Vocabulary", required=True),  # half
+        PathStep(ExerciseType.FILL_BLANKS, "Key Terms"),                         # half (pair)
+        PathStep(ExerciseType.YOUTUBE_TASK, "Video Comprehension"),              # full
+        PathStep(ExerciseType.DRAWING_TASK, "Visual Response"),                  # half
+        PathStep(ExerciseType.TRANSLATION, "Translation Practice"),              # half (pair)
+        PathStep(ExerciseType.CREATIVE_WRITING, "Reflection"),                   # full
     ],
 )
 

--- a/src/langwich/paths/template.py
+++ b/src/langwich/paths/template.py
@@ -43,13 +43,13 @@ class ExerciseType(str, enum.Enum):
 #: Default size for each exercise type.  Individual ``PathStep`` instances can
 #: override this via their ``size`` attribute.
 DEFAULT_TASK_SIZES: dict[ExerciseType, TaskSize] = {
-    ExerciseType.VOCAB_MATCHING: TaskSize.FULL,
+    ExerciseType.VOCAB_MATCHING: TaskSize.HALF,
     ExerciseType.FILL_BLANKS: TaskSize.HALF,
     ExerciseType.SYNONYMS: TaskSize.HALF,
     ExerciseType.TRANSLATION: TaskSize.HALF,
     ExerciseType.READING_COMPREHENSION: TaskSize.DOUBLE,
     ExerciseType.CREATIVE_WRITING: TaskSize.FULL,
-    ExerciseType.TEXT_SUMMARY: TaskSize.DOUBLE,
+    ExerciseType.TEXT_SUMMARY: TaskSize.FULL,
     ExerciseType.YOUTUBE_TASK: TaskSize.FULL,
     ExerciseType.DRAWING_TASK: TaskSize.HALF,
 }

--- a/src/langwich/paths/template.py
+++ b/src/langwich/paths/template.py
@@ -12,6 +12,20 @@ from dataclasses import dataclass, field
 from typing import Any
 
 
+class TaskSize(str, enum.Enum):
+    """How much vertical space an exercise should occupy on the worksheet.
+
+    - ``HALF``   — half a page (~350 pt usable height on A4).  Must be paired
+      with another HALF task so the two together fill one page.
+    - ``FULL``   — exactly one page.
+    - ``DOUBLE`` — exactly two pages.
+    """
+
+    HALF = "half"
+    FULL = "full"
+    DOUBLE = "double"
+
+
 class ExerciseType(str, enum.Enum):
     """Registry of all supported exercise types."""
 
@@ -24,6 +38,21 @@ class ExerciseType(str, enum.Enum):
     TEXT_SUMMARY = "text_summary"
     YOUTUBE_TASK = "youtube_task"
     DRAWING_TASK = "drawing_task"
+
+
+#: Default size for each exercise type.  Individual ``PathStep`` instances can
+#: override this via their ``size`` attribute.
+DEFAULT_TASK_SIZES: dict[ExerciseType, TaskSize] = {
+    ExerciseType.VOCAB_MATCHING: TaskSize.FULL,
+    ExerciseType.FILL_BLANKS: TaskSize.HALF,
+    ExerciseType.SYNONYMS: TaskSize.HALF,
+    ExerciseType.TRANSLATION: TaskSize.HALF,
+    ExerciseType.READING_COMPREHENSION: TaskSize.DOUBLE,
+    ExerciseType.CREATIVE_WRITING: TaskSize.FULL,
+    ExerciseType.TEXT_SUMMARY: TaskSize.DOUBLE,
+    ExerciseType.YOUTUBE_TASK: TaskSize.FULL,
+    ExerciseType.DRAWING_TASK: TaskSize.HALF,
+}
 
 
 @dataclass
@@ -40,16 +69,27 @@ class PathStep:
         Exercise-specific configuration (e.g. ``{"num_items": 10}``).
     required : bool
         Whether this step must be included even if vocabulary is scarce.
+    size : TaskSize | None
+        Explicit size override.  When *None* the default from
+        ``DEFAULT_TASK_SIZES`` is used.
     """
 
     exercise_type: ExerciseType
     title: str = ""
     config: dict[str, Any] = field(default_factory=dict)
     required: bool = False
+    size: TaskSize | None = None
 
     def __post_init__(self) -> None:
         if not self.title:
             self.title = self.exercise_type.value.replace("_", " ").title()
+
+    @property
+    def resolved_size(self) -> TaskSize:
+        """Return the effective task size (explicit override or default)."""
+        if self.size is not None:
+            return self.size
+        return DEFAULT_TASK_SIZES.get(self.exercise_type, TaskSize.FULL)
 
 
 @dataclass
@@ -85,6 +125,34 @@ class LearningPath:
             )
             self.steps.insert(0, vocab_step)
 
+    def validate_half_pairing(self) -> None:
+        """Check that HALF-page tasks appear in consecutive pairs.
+
+        Raises ``ValueError`` if an unpaired HALF task is found.
+        """
+        pending_half: PathStep | None = None
+        for step in self.steps:
+            if step.resolved_size == TaskSize.HALF:
+                if pending_half is None:
+                    pending_half = step
+                else:
+                    # Pair completed
+                    pending_half = None
+            else:
+                if pending_half is not None:
+                    raise ValueError(
+                        f"Half-page task '{pending_half.title}' "
+                        f"({pending_half.exercise_type.value}) is not paired "
+                        f"with another half-page task.  Half tasks must appear "
+                        f"in consecutive pairs."
+                    )
+        if pending_half is not None:
+            raise ValueError(
+                f"Half-page task '{pending_half.title}' "
+                f"({pending_half.exercise_type.value}) has no partner — "
+                f"half tasks must appear in consecutive pairs."
+            )
+
     def exercise_types(self) -> list[ExerciseType]:
         """Return the ordered list of exercise types in this path."""
         return [step.exercise_type for step in self.steps]
@@ -101,6 +169,7 @@ class LearningPath:
                     "title": step.title,
                     "config": step.config,
                     "required": step.required,
+                    "size": step.size.value if step.size else None,
                 }
                 for step in self.steps
             ],
@@ -115,6 +184,7 @@ class LearningPath:
                 title=s.get("title", ""),
                 config=s.get("config", {}),
                 required=s.get("required", False),
+                size=TaskSize(s["size"]) if s.get("size") else None,
             )
             for s in data.get("steps", [])
         ]

--- a/src/langwich/rendering/components.py
+++ b/src/langwich/rendering/components.py
@@ -28,6 +28,14 @@ from langwich.rendering.styles import (
     body_style,
 )
 
+# ── Page geometry constants ─────────────────────────────────────────
+# A4 usable height after margins (48 pt each) + header/footer (20 pt each).
+# Total vertical margin = 2 × (48 + 20) = 136 pt.
+# A4 height = 841.89 pt → usable ≈ 705.89 pt.
+from reportlab.lib.pagesizes import A4
+
+A4_USABLE_HEIGHT = A4[1] - 2 * (48 + 20)  # ~705.89 pt
+
 
 class MinHeightFlowable(Flowable):
     """Wrapper that enforces a minimum height on a contained flowable."""
@@ -255,3 +263,56 @@ def section_divider() -> list[Flowable]:
         Spacer(1, SPACE_SM),
         HRFlowable(width="100%", thickness=1, color=BORDER_GREY, spaceAfter=SPACE_SM),
     ]
+
+
+# ── Size-aware layout helpers ───────────────────────────────────────
+
+class PageFillerFlowable(Flowable):
+    """Invisible spacer that pads content to fill a target height exactly.
+
+    Used to ensure an exercise occupies precisely half / full / double page.
+    Wraps a list of child flowables, measures them, then adds blank space so
+    that the total height equals ``target_height``.
+    """
+
+    def __init__(self, children: list[Flowable], target_height: float) -> None:
+        super().__init__()
+        self._children = children
+        self._target_height = target_height
+
+    def wrap(self, availWidth: float, availHeight: float) -> tuple[float, float]:
+        self._avail_width = availWidth
+        content_h = 0.0
+        for child in self._children:
+            w, h = child.wrap(availWidth, availHeight)
+            content_h += h
+        self.width = availWidth
+        self.height = max(content_h, self._target_height)
+        return self.width, self.height
+
+    def split(self, availWidth: float, availHeight: float) -> list[Flowable]:
+        # Allow ReportLab to page-break within the children normally.
+        return self._children
+
+    def draw(self) -> None:
+        y = self.height
+        for child in self._children:
+            w, h = child.wrap(self._avail_width, self.height)
+            y -= h
+            child.drawOn(self.canv, 0, y)
+
+
+def target_height_for_size(size: str, usable_height: float | None = None) -> float:
+    """Return the target height in points for a ``TaskSize`` value.
+
+    Parameters
+    ----------
+    size : str
+        One of ``"half"``, ``"full"``, ``"double"``.
+    usable_height : float | None
+        Override for the usable page height (defaults to A4 with standard
+        langwich margins).
+    """
+    h = usable_height or A4_USABLE_HEIGHT
+    multipliers = {"half": 0.5, "full": 1.0, "double": 2.0}
+    return h * multipliers.get(size, 1.0)

--- a/src/langwich/rendering/pdf_renderer.py
+++ b/src/langwich/rendering/pdf_renderer.py
@@ -15,7 +15,9 @@ from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import cm
 from reportlab.platypus import (
     BaseDocTemplate,
+    CondPageBreak,
     Frame,
+    PageBreak,
     PageTemplate,
     Paragraph,
     Spacer,
@@ -24,7 +26,13 @@ from reportlab.platypus import (
 
 from langwich.config import PDFConfig, settings
 from langwich.db.models import CEFRLevel
-from langwich.rendering.components import section_divider
+from langwich.paths.template import TaskSize
+from langwich.rendering.components import (
+    A4_USABLE_HEIGHT,
+    PageFillerFlowable,
+    section_divider,
+    target_height_for_size,
+)
 from langwich.rendering.styles import (
     BRAND_DARK,
     BRAND_GREY,
@@ -59,6 +67,7 @@ class PDFRenderer:
         domain: str = "",
         level: CEFRLevel = CEFRLevel.B1,
         worksheet_date: date | None = None,
+        exercise_sizes: list[TaskSize | None] | None = None,
     ) -> Path:
         """Build and save the PDF worksheet.
 
@@ -76,6 +85,13 @@ class PDFRenderer:
             Target CEFR level for the header badge.
         worksheet_date : date | None
             Date to print; defaults to today.
+        exercise_sizes : list[TaskSize | None] | None
+            Parallel list of sizes for each exercise section.  Entries
+            that are *None* (or if the whole list is *None*) get the old
+            free-flow behaviour.  When sizes are given the renderer pads
+            each exercise to the target height and inserts page breaks so
+            that half-page pairs share a page, full tasks get one page,
+            and double tasks get two pages.
 
         Returns
         -------
@@ -147,11 +163,84 @@ class PDFRenderer:
         story.append(Paragraph(title, title_style()))
         story.append(Spacer(1, SPACE_LG))
 
-        for i, section_flowables in enumerate(exercise_flowables):
-            if i > 0:
-                story.extend(section_divider())
-            story.extend(section_flowables)
+        # Normalise the sizes list so it is always parallel with flowables.
+        sizes: list[TaskSize | None] = list(exercise_sizes) if exercise_sizes else []
+        while len(sizes) < len(exercise_flowables):
+            sizes.append(None)
+
+        self._build_sized_story(story, exercise_flowables, sizes)
 
         doc.build(story)
         logger.info("PDF written to %s", output_path)
         return output_path
+
+    # ── Internal helpers ────────────────────────────────────────────
+
+    @staticmethod
+    def _build_sized_story(
+        story: list[Flowable],
+        sections: list[list[Flowable]],
+        sizes: list[TaskSize | None],
+    ) -> None:
+        """Append exercise sections to *story* respecting size constraints.
+
+        Half-page tasks are consumed in pairs and placed on the same page
+        separated by a divider.  Full and double tasks each start on a
+        fresh page.
+        """
+        half_height = target_height_for_size(TaskSize.HALF.value)
+        idx = 0
+        is_first_exercise = True
+
+        while idx < len(sections):
+            size = sizes[idx]
+            flowables = sections[idx]
+
+            if size is None:
+                # Legacy / unsized section — free-flow with dividers
+                if not is_first_exercise:
+                    story.extend(section_divider())
+                story.extend(flowables)
+                idx += 1
+
+            elif size == TaskSize.HALF:
+                # Consume the next section as the pair partner
+                if not is_first_exercise:
+                    story.append(PageBreak())
+                partner_flowables = sections[idx + 1] if idx + 1 < len(sections) else []
+
+                # First half
+                story.append(
+                    PageFillerFlowable(list(flowables), half_height)
+                )
+                # Divider between the two halves
+                story.extend(section_divider())
+                # Second half
+                if partner_flowables:
+                    story.append(
+                        PageFillerFlowable(list(partner_flowables), half_height)
+                    )
+                idx += 2
+
+            elif size == TaskSize.FULL:
+                if not is_first_exercise:
+                    story.append(PageBreak())
+                target_h = target_height_for_size(TaskSize.FULL.value)
+                story.append(PageFillerFlowable(list(flowables), target_h))
+                idx += 1
+
+            elif size == TaskSize.DOUBLE:
+                if not is_first_exercise:
+                    story.append(PageBreak())
+                target_h = target_height_for_size(TaskSize.DOUBLE.value)
+                story.append(PageFillerFlowable(list(flowables), target_h))
+                idx += 1
+
+            else:
+                # Unknown size — fall through to free-flow
+                if not is_first_exercise:
+                    story.extend(section_divider())
+                story.extend(flowables)
+                idx += 1
+
+            is_first_exercise = False


### PR DESCRIPTION
Introduces a TaskSize enum (HALF/FULL/DOUBLE) that controls how much
vertical space each exercise occupies on the worksheet. Half-page tasks
are required to appear in consecutive pairs so they share a single page.

- TaskSize enum + DEFAULT_TASK_SIZES mapping per exercise type
- PathStep.size override + resolved_size property
- LearningPath.validate_half_pairing() enforcement
- PageFillerFlowable pads exercises to exact target height
- PDFRenderer._build_sized_story() handles page breaks and pairing
- Default paths updated to ensure all half-page tasks are paired

https://claude.ai/code/session_01SYiaoagdCkB3jVBt8cDtAh