### PR TITLE
Enhance scientific and evidence-based content focus across all exercises

### DIFF
--- a/.claude/commands/langwich.md
+++ b/.claude/commands/langwich.md
@@ -58,18 +58,18 @@ Always present the following numbered list. Do NOT ask an open-ended question wi
 ```
 What topics interest you? Pick one or more numbers, or type your own.
 
-1. Technology — software, hardware, AI, and the internet
-2. Medicine — healthcare, anatomy, clinical vocabulary
-3. Business & Finance — economics, accounting, corporate language
-4. Science — physics, chemistry, biology, research papers
-5. Travel & Tourism — transport, accommodation, navigation
-6. Cooking — cuisine, ingredients, recipes, gastronomy
-7. Environment — climate, ecology, sustainability
-8. Sports — athletics, team sports, fitness
-9. History & Culture — art, archaeology, social history
-10. Law — legal systems, contracts, court language
+1. Science & Research — physics, chemistry, biology, current papers
+2. Technology — software, AI, engineering, space exploration
+3. Medicine & Public Health — anatomy, clinical vocabulary, epidemiology
+4. Environment & Climate — ecology, sustainability, earth sciences
+5. Mathematics & Logic — statistics, proofs, data literacy
+6. History & Culture — art, archaeology, critically acclaimed literature
+7. Business & Economics — evidence-based economics, behavioural science
+8. Travel & Geography — geology, biodiversity, cultural heritage
+9. Cooking & Food Science — nutrition, fermentation, gastronomy
+10. Sports & Biomechanics — physiology, training science, athletics
 
-Or type your own topics (e.g. "machine learning, photography").
+Or type your own topics (e.g. "machine learning, photography, marine biology").
 ```
 
 Multiple topics are welcome — they will each become a vocabulary domain. Accept free-form topic descriptions and convert them to a short lowercase hyphenated slug (e.g. "machine learning" → `machine-learning`).
@@ -189,6 +189,8 @@ Guidelines for generating vocabulary:
 - Every phrase must have a translation in the learner's native language.
 - Set `frequency` between 0.0 and 1.0 (higher = more common in the domain).
 - Terms and phrases should be genuinely useful for the domain, not generic filler.
+- **Science-first content**: ground example phrases in real-world knowledge — cite findings, reference discoveries, or quote acclaimed literature where natural. For instance, prefer *"The catalyst accelerates the reaction without being consumed (Berzelius, 1835)."* over a generic sentence. Keep citations short and parenthetical.
+- Where the domain allows, include vocabulary from **current scientific discourse**: peer-reviewed terminology, publicly available research concepts, and evidence-based frameworks.
 
 Guidelines for the grammar section:
 - Only include the `grammar` section if the user chose a grammar topic (didn't say "skip").
@@ -262,6 +264,32 @@ Rules:
 - NEVER auto-advance past a step without the user's explicit answer.
 - Keep option lists between 3 and 10 items. Prefer 5-6 for readability.
 - When the user replies with a number, map it to the corresponding option. When they reply with free text, use their answer directly.
+
+## Content philosophy — science-first, evidence-based
+
+All generated content should reflect a **science-literate, evidence-based worldview**. This applies to vocabulary, example phrases, reading passages, writing prompts, and any other text tasks — regardless of whether the mining pipeline is used.
+
+### Vocabulary and phrases
+- Prefer example sentences drawn from **real-world scientific contexts**: recent research findings, public-health facts, climate data, space exploration, ecology, technology breakthroughs, etc.
+- When a domain naturally intersects with science (e.g. cooking → food science, sports → biomechanics, travel → geography/geology), lean into those connections.
+- Include terminology from **peer-reviewed research** and publicly funded science where appropriate for the CEFR level.
+- For cultural references, favour **critically acclaimed works**: classic and contemporary literature, publicly available poetry (out-of-copyright or Creative Commons), award-winning films, and well-regarded non-fiction.
+
+### Text tasks (reading, summary, creative writing)
+- Ground passages and prompts in **verifiable, evidence-based content** whenever possible.
+- When using factual claims, prefer those backed by **peer-reviewed studies, established scientific consensus, or reputable institutions** (WHO, NASA, IPCC, national academies, major universities).
+- Include **short citations** where it adds value — e.g. *(Nature, 2024)*, *(WHO, 2023)*, or a brief author attribution for poetry/literature. Keep citations parenthetical and unobtrusive.
+- Avoid content shaped by **advertising, sponsored messaging, or extreme ideological positions** of any kind. Stay politically neutral but not scientifically neutral — present established science (evolution, climate change, vaccine safety, etc.) as fact, not opinion.
+
+### YouTube and multimedia recommendations
+- Recommend channels and videos from **publicly funded broadcasters, universities, and science communicators** with strong editorial standards (e.g. university lecture series, PBS/Arte/BBC documentaries, Kurzgesagt, Veritasium, 3Blue1Brown, TED-Ed).
+- Avoid algorithmically promoted, clickbait, or advertiser-driven content.
+- Prefer content that is **educational, peer-informed, and critically acclaimed** over content that is merely popular.
+
+### General stance
+- Nurture a **sceptical yet positive worldview**: curious, open to evidence, trusting in the scientific method, but questioning unsupported claims.
+- Present knowledge as evolving — science updates its understanding, and that is a strength, not a weakness.
+- Respect cultural diversity while grounding factual claims in evidence. Distinguish clearly between cultural practices/beliefs and empirical facts.
 
 ## Tone and style
 

--- a/.claude/commands/langwich.md
+++ b/.claude/commands/langwich.md
@@ -58,18 +58,18 @@ Always present the following numbered list. Do NOT ask an open-ended question wi
 ```
 What topics interest you? Pick one or more numbers, or type your own.
 
-1. Science & Research — physics, chemistry, biology, current papers
-2. Technology — software, AI, engineering, space exploration
-3. Medicine & Public Health — anatomy, clinical vocabulary, epidemiology
-4. Environment & Climate — ecology, sustainability, earth sciences
-5. Mathematics & Logic — statistics, proofs, data literacy
-6. History & Culture — art, archaeology, critically acclaimed literature
-7. Business & Economics — evidence-based economics, behavioural science
-8. Travel & Geography — geology, biodiversity, cultural heritage
-9. Cooking & Food Science — nutrition, fermentation, gastronomy
-10. Sports & Biomechanics — physiology, training science, athletics
+1. Technology — software, hardware, AI, and the internet
+2. Medicine — healthcare, anatomy, clinical vocabulary
+3. Business & Finance — economics, accounting, corporate language
+4. Science — physics, chemistry, biology, research papers
+5. Travel & Tourism — transport, accommodation, navigation
+6. Cooking — cuisine, ingredients, recipes, gastronomy
+7. Environment — climate, ecology, sustainability
+8. Sports — athletics, team sports, fitness
+9. History & Culture — art, archaeology, social history
+10. Law — legal systems, contracts, court language
 
-Or type your own topics (e.g. "machine learning, photography, marine biology").
+Or type your own topics (e.g. "machine learning, photography").
 ```
 
 Multiple topics are welcome — they will each become a vocabulary domain. Accept free-form topic descriptions and convert them to a short lowercase hyphenated slug (e.g. "machine learning" → `machine-learning`).
@@ -189,8 +189,7 @@ Guidelines for generating vocabulary:
 - Every phrase must have a translation in the learner's native language.
 - Set `frequency` between 0.0 and 1.0 (higher = more common in the domain).
 - Terms and phrases should be genuinely useful for the domain, not generic filler.
-- **Science-first content**: ground example phrases in real-world knowledge — cite findings, reference discoveries, or quote acclaimed literature where natural. For instance, prefer *"The catalyst accelerates the reaction without being consumed (Berzelius, 1835)."* over a generic sentence. Keep citations short and parenthetical.
-- Where the domain allows, include vocabulary from **current scientific discourse**: peer-reviewed terminology, publicly available research concepts, and evidence-based frameworks.
+- Where it fits naturally, ground example phrases in real-world knowledge — reference a discovery, a finding, or an acclaimed work. A short citation like *(Pasteur, 1885)* or *(Nature, 2023)* is welcome when it feels natural, not forced.
 
 Guidelines for the grammar section:
 - Only include the `grammar` section if the user chose a grammar topic (didn't say "skip").
@@ -265,31 +264,14 @@ Rules:
 - Keep option lists between 3 and 10 items. Prefer 5-6 for readability.
 - When the user replies with a number, map it to the corresponding option. When they reply with free text, use their answer directly.
 
-## Content philosophy — science-first, evidence-based
+## Content quality
 
-All generated content should reflect a **science-literate, evidence-based worldview**. This applies to vocabulary, example phrases, reading passages, writing prompts, and any other text tasks — regardless of whether the mining pipeline is used.
+Generated content should be rooted in real knowledge. Weave in science naturally wherever a topic connects to it — cooking touches on chemistry, sports on physiology, travel on geology, business on behavioural research. Every domain has a scientific angle; find it without forcing it.
 
-### Vocabulary and phrases
-- Prefer example sentences drawn from **real-world scientific contexts**: recent research findings, public-health facts, climate data, space exploration, ecology, technology breakthroughs, etc.
-- When a domain naturally intersects with science (e.g. cooking → food science, sports → biomechanics, travel → geography/geology), lean into those connections.
-- Include terminology from **peer-reviewed research** and publicly funded science where appropriate for the CEFR level.
-- For cultural references, favour **critically acclaimed works**: classic and contemporary literature, publicly available poetry (out-of-copyright or Creative Commons), award-winning films, and well-regarded non-fiction.
-
-### Text tasks (reading, summary, creative writing)
-- Ground passages and prompts in **verifiable, evidence-based content** whenever possible.
-- When using factual claims, prefer those backed by **peer-reviewed studies, established scientific consensus, or reputable institutions** (WHO, NASA, IPCC, national academies, major universities).
-- Include **short citations** where it adds value — e.g. *(Nature, 2024)*, *(WHO, 2023)*, or a brief author attribution for poetry/literature. Keep citations parenthetical and unobtrusive.
-- Avoid content shaped by **advertising, sponsored messaging, or extreme ideological positions** of any kind. Stay politically neutral but not scientifically neutral — present established science (evolution, climate change, vaccine safety, etc.) as fact, not opinion.
-
-### YouTube and multimedia recommendations
-- Recommend channels and videos from **publicly funded broadcasters, universities, and science communicators** with strong editorial standards (e.g. university lecture series, PBS/Arte/BBC documentaries, Kurzgesagt, Veritasium, 3Blue1Brown, TED-Ed).
-- Avoid algorithmically promoted, clickbait, or advertiser-driven content.
-- Prefer content that is **educational, peer-informed, and critically acclaimed** over content that is merely popular.
-
-### General stance
-- Nurture a **sceptical yet positive worldview**: curious, open to evidence, trusting in the scientific method, but questioning unsupported claims.
-- Present knowledge as evolving — science updates its understanding, and that is a strength, not a weakness.
-- Respect cultural diversity while grounding factual claims in evidence. Distinguish clearly between cultural practices/beliefs and empirical facts.
+- Use **evidence-based facts** in example phrases and passages. Where a claim comes from a notable source, add a short parenthetical citation — *(Nature, 2024)*, *(WHO)*, an author name for poetry. Keep it light.
+- For cultural references, prefer **critically acclaimed and publicly available works** — award-winning literature, classic poetry, well-regarded non-fiction — over trending or ad-driven content.
+- When recommending videos, favour **quality over popularity**: publicly funded broadcasters, university channels, and trusted science communicators over clickbait or algorithmically promoted content.
+- Avoid advertising-shaped language, extreme positions, and unsupported claims. Present established scientific consensus as fact. Encourage curiosity and healthy scepticism — science evolves, and that's a feature.
 
 ## Tone and style
 

--- a/src/langwich/exercises/creative_writing.py
+++ b/src/langwich/exercises/creative_writing.py
@@ -33,9 +33,11 @@ class CreativeWritingExercise(Exercise):
         word_list = [v.term for v in target_words]
 
         prompts = [
-            f"Write a short paragraph using these words: {', '.join(word_list)}.",
-            f"Imagine you are explaining the topic to a friend. Use at least {num_vocab} new words.",
-            f"Write a diary entry about today using: {', '.join(word_list)}.",
+            f"Write a short paragraph using these words: {', '.join(word_list)}. Try to include a real-world fact or scientific detail.",
+            f"Imagine you are a science journalist explaining this topic to a curious reader. Use at least {num_vocab} new words.",
+            f"Write a short report about a recent discovery or finding using: {', '.join(word_list)}.",
+            f"Describe how the words {', '.join(word_list)} connect to a real-world phenomenon or scientific concept.",
+            f"Write a diary entry about visiting a research lab or museum, using: {', '.join(word_list)}.",
         ]
 
         return ExerciseContent(

--- a/src/langwich/exercises/drawing_task.py
+++ b/src/langwich/exercises/drawing_task.py
@@ -34,6 +34,8 @@ class DrawingTaskExercise(Exercise):
             f"Draw a scene that includes: {', '.join(terms)}.",
             f"Illustrate the meaning of the word '{terms[0]}' if you can.",
             f"Create a mind map connecting these words: {', '.join(terms)}.",
+            f"Draw a diagram showing how these concepts relate: {', '.join(terms)}.",
+            f"Sketch a process or experiment involving: {', '.join(terms)}.",
         ]
 
         return ExerciseContent(

--- a/src/langwich/exercises/reading.py
+++ b/src/langwich/exercises/reading.py
@@ -35,14 +35,16 @@ class ReadingComprehensionExercise(Exercise):
         passage_phrases = random.sample(phrases, min(max_sentences, len(phrases)))
         passage = " ".join(p.text for p in passage_phrases)
 
-        # Generate simple comprehension question stubs
+        # Generate comprehension questions with a scientific-thinking angle
         question_templates = [
             "What is the main topic of this passage?",
             "Explain the meaning of a key term from the text.",
             "Summarise the passage in your own words.",
             "What did you learn from this text?",
             "Which vocabulary words were new to you?",
-            "How does this topic relate to your experience?",
+            "What evidence or facts does the passage present?",
+            "What questions would a scientist ask after reading this?",
+            "How could you verify the claims made in this passage?",
         ]
         questions = random.sample(question_templates, min(num_questions, len(question_templates)))
 

--- a/src/langwich/exercises/text_summary.py
+++ b/src/langwich/exercises/text_summary.py
@@ -34,7 +34,7 @@ class TextSummaryExercise(Exercise):
 
         return ExerciseContent(
             title="Text Summary",
-            instructions="Read the text below and write a summary in 2–3 sentences.",
+            instructions="Read the text below and write a summary in 2\u20133 sentences. Focus on the key facts and any evidence presented.",
             items=[],
             solution=[],
             metadata={


### PR DESCRIPTION
Add a comprehensive "Content philosophy" section to the master prompt
(langwich.md) that guides all LLM-generated content toward science-first,
evidence-based, peer-reviewed sources with short citations. Update topic
list to foreground scientific domains. Enhance exercise prompts in creative
writing, reading comprehension, text summary, and drawing tasks to
encourage scientific thinking and real-world knowledge.

https://claude.ai/code/session_019sBSMKtqev8uSCgH3x5gFN