### PR TITLE
Fix worksheet content overlap, layout gaps, and vocabulary overflow

### DIFF
--- a/src/langwich/exercises/reading.py
+++ b/src/langwich/exercises/reading.py
@@ -16,7 +16,7 @@ class ReadingComprehensionExercise(Exercise):
     """Present a text passage and comprehension questions.
 
     The passage is assembled from example phrases in the database.
-    Config: num_questions (default 4), max_passage_sentences (default 15)
+    Config: num_questions (default 4), max_passage_sentences (default 20)
     """
 
     @property
@@ -29,25 +29,61 @@ class ReadingComprehensionExercise(Exercise):
         phrases: list[PhraseEntry],
         level: CEFRLevel,
     ) -> ExerciseContent:
-        max_sentences = self.config.get("max_passage_sentences", 15)
+        max_sentences = self.config.get("max_passage_sentences", 20)
         num_questions = self.config.get("num_questions", 4)
 
         passage_phrases = random.sample(phrases, min(max_sentences, len(phrases)))
         passage = " ".join(p.text for p in passage_phrases)
 
-        # Generate comprehension questions with a scientific-thinking angle
-        question_templates = [
-            "What is the main topic of this passage?",
-            "Explain the meaning of a key term from the text.",
-            "Summarise the passage in your own words.",
-            "What did you learn from this text?",
-            "Which vocabulary words were new to you?",
-            "What evidence or facts does the passage present?",
-            "What questions would a scientist ask after reading this?",
-            "How could you verify the claims made in this passage?",
-        ]
-        questions = random.sample(question_templates, min(num_questions, len(question_templates)))
+        # Build questions that reference the actual passage content.
+        # Pick a few concrete terms from the text so questions feel relevant.
+        all_words = [w for p in passage_phrases for w in p.text.split() if len(w) > 4 and w.isalpha()]
+        sample_terms = random.sample(all_words, min(3, len(all_words))) if all_words else []
 
+        questions: list[str] = []
+
+        # First question always asks about the topic
+        questions.append("What is the main topic of this text? Write 1–2 sentences.")
+
+        # Term-specific question using a word from the passage
+        if len(sample_terms) >= 1:
+            questions.append(
+                f"The word \u201c{sample_terms[0]}\u201d appears in the text. "
+                f"Explain what it means in this context."
+            )
+
+        # Factual question
+        questions.append(
+            "Name two facts or details mentioned in the text."
+        )
+
+        # Comprehension / inference question
+        if len(sample_terms) >= 2:
+            questions.append(
+                f"How does the text connect \u201c{sample_terms[1]}\u201d "
+                f"to the overall topic?"
+            )
+
+        # Personal response
+        questions.append(
+            "What is the most important thing you learned from this text? Why?"
+        )
+
+        # Extra pool for variety
+        extra = [
+            "Summarise the text in 2\u20133 sentences using your own words.",
+            "Which sentence in the text do you find most interesting? Explain why.",
+            "Write one question you would like to ask the author of this text.",
+        ]
+        random.shuffle(extra)
+
+        # Fill up to num_questions
+        for q in extra:
+            if len(questions) >= num_questions:
+                break
+            questions.append(q)
+
+        questions = questions[:num_questions]
         items = [{"number": i, "question": q} for i, q in enumerate(questions, 1)]
 
         return ExerciseContent(

--- a/src/langwich/exercises/text_summary.py
+++ b/src/langwich/exercises/text_summary.py
@@ -15,7 +15,7 @@ from langwich.exercises.base import Exercise, ExerciseContent
 class TextSummaryExercise(Exercise):
     """Ask students to summarise a passage in a target word count.
 
-    Config: max_passage_sentences (default 6), summary_lines (default 5)
+    Config: max_passage_sentences (default 10), summary_lines (default 5)
     """
 
     @property
@@ -28,7 +28,7 @@ class TextSummaryExercise(Exercise):
         phrases: list[PhraseEntry],
         level: CEFRLevel,
     ) -> ExerciseContent:
-        max_sentences = self.config.get("max_passage_sentences", 12)
+        max_sentences = self.config.get("max_passage_sentences", 10)
         passage_phrases = random.sample(phrases, min(max_sentences, len(phrases)))
         passage = " ".join(p.text for p in passage_phrases)
 

--- a/src/langwich/generator.py
+++ b/src/langwich/generator.py
@@ -10,6 +10,7 @@ This is the primary entry point for generating worksheets. It:
 from __future__ import annotations
 
 import logging
+import random
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -152,6 +153,26 @@ class WorksheetGenerator:
             all_flowables.append(grammar_flowables)
             all_sizes.append(None)
 
+        # Partition phrases so text-consuming exercises get disjoint sets.
+        # This prevents the reading passage and fill-in-the-blanks from
+        # showing the same sentences.
+        TEXT_PASSAGE_TYPES = {
+            ExerciseType.READING_COMPREHENSION,
+            ExerciseType.FILL_BLANKS,
+            ExerciseType.TEXT_SUMMARY,
+        }
+        text_steps = [s for s in self.path.steps if s.exercise_type in TEXT_PASSAGE_TYPES]
+
+        phrase_pools: dict[int, list] = {}
+        if text_steps and phrases:
+            shuffled = list(phrases)
+            random.shuffle(shuffled)
+            pool_size = max(1, len(shuffled) // len(text_steps))
+            for i, step in enumerate(text_steps):
+                start = i * pool_size
+                end = start + pool_size if i < len(text_steps) - 1 else len(shuffled)
+                phrase_pools[id(step)] = shuffled[start:end]
+
         # Generate content for each exercise step
         for step in self.path.steps:
             exercise_cls = EXERCISE_REGISTRY.get(step.exercise_type)
@@ -159,9 +180,12 @@ class WorksheetGenerator:
                 logger.warning("Unknown exercise type: %s", step.exercise_type)
                 continue
 
+            # Use the partitioned phrase pool for text exercises, full set otherwise
+            step_phrases = phrase_pools.get(id(step), phrases)
+
             exercise = exercise_cls(config=step.config)
             try:
-                content = exercise.generate(vocabulary, phrases, self.level)
+                content = exercise.generate(vocabulary, step_phrases, self.level)
                 flowables = exercise.render(content)
                 all_flowables.append(flowables)
                 all_sizes.append(step.resolved_size)

--- a/src/langwich/rendering/components.py
+++ b/src/langwich/rendering/components.py
@@ -184,12 +184,19 @@ def vocab_reference_page(
     vocabulary: list[Any],
     source_lang: str = "",
     target_lang: str = "",
+    max_entries: int = 30,
 ) -> list[Flowable]:
     """Render a full vocabulary reference table with terms and translations.
 
-    This is a dedicated vocabulary page placed at the beginning of the
-    worksheet, listing all terms with their translations grouped by
-    part of speech.
+    This is a dedicated vocabulary page placed at the beginning or end of
+    the worksheet, listing terms with their translations grouped by part
+    of speech.
+
+    Parameters
+    ----------
+    max_entries : int
+        Maximum number of vocabulary rows to display.  Keeps the table
+        on a single page even when followed by info boxes.
     """
     import json
 
@@ -218,7 +225,7 @@ def vocab_reference_page(
         pos_label = entry.part_of_speech.value if hasattr(entry.part_of_speech, "value") else str(entry.part_of_speech)
         by_pos[pos_label].append((entry.term, trans_str))
 
-    # Build table rows
+    # Build table rows, respecting the max_entries limit
     from langwich.rendering.styles import BRAND_ACCENT, BRAND_GREY
 
     table_data = []
@@ -227,12 +234,18 @@ def vocab_reference_page(
     trans_label = source_lang.upper() if source_lang else "Translation"
     table_data.append([term_label, "", trans_label])
 
+    entry_count = 0
     for pos, pairs in sorted(by_pos.items()):
+        if entry_count >= max_entries:
+            break
         # POS header row
         pos_display = pos.replace("_", " ").title() if pos else "Other"
         table_data.append([Paragraph(f"<b>{pos_display}</b>", body_style()), "", ""])
         for term, trans in sorted(pairs):
+            if entry_count >= max_entries:
+                break
             table_data.append([term, "→", trans])
+            entry_count += 1
 
     if len(table_data) <= 1:
         return flowables

--- a/src/langwich/rendering/pdf_renderer.py
+++ b/src/langwich/rendering/pdf_renderer.py
@@ -187,26 +187,41 @@ class PDFRenderer:
         Half-page tasks are consumed in pairs and placed on the same page
         separated by a divider.  Full and double tasks each start on a
         fresh page.
+
+        Free-flow (None-sized) sections flow naturally.  A ``CondPageBreak``
+        is used instead of a hard ``PageBreak`` so that transitions from
+        short free-flow sections (e.g. a grammar reference) into sized
+        exercises do not leave blank pages.
         """
         half_height = target_height_for_size(TaskSize.HALF.value)
+        full_height = target_height_for_size(TaskSize.FULL.value)
         idx = 0
         is_first_exercise = True
+        had_sized_section = False
 
         while idx < len(sections):
             size = sizes[idx]
             flowables = sections[idx]
 
             if size is None:
-                # Legacy / unsized section — free-flow with dividers
-                if not is_first_exercise:
+                # Free-flow section (grammar page, vocab reference, AI tip).
+                if had_sized_section:
+                    # After a sized exercise finished, start a new page.
+                    story.append(PageBreak())
+                    had_sized_section = False
+                elif not is_first_exercise:
                     story.extend(section_divider())
                 story.extend(flowables)
                 idx += 1
 
             elif size == TaskSize.HALF:
-                # Consume the next section as the pair partner
-                if not is_first_exercise:
+                # Consume the next section as the pair partner.
+                if had_sized_section:
                     story.append(PageBreak())
+                elif not is_first_exercise:
+                    # After free-flow content, only break if there isn't
+                    # enough room for the full half-pair.
+                    story.append(CondPageBreak(half_height * 2))
                 partner_flowables = sections[idx + 1] if idx + 1 < len(sections) else []
 
                 # First half
@@ -221,13 +236,17 @@ class PDFRenderer:
                         PageFillerFlowable(list(partner_flowables), half_height)
                     )
                 idx += 2
+                had_sized_section = True
 
             elif size == TaskSize.FULL:
-                if not is_first_exercise:
+                if had_sized_section:
                     story.append(PageBreak())
-                target_h = target_height_for_size(TaskSize.FULL.value)
+                elif not is_first_exercise:
+                    story.append(CondPageBreak(full_height))
+                target_h = full_height
                 story.append(PageFillerFlowable(list(flowables), target_h))
                 idx += 1
+                had_sized_section = True
 
             elif size == TaskSize.DOUBLE:
                 if not is_first_exercise:
@@ -235,10 +254,14 @@ class PDFRenderer:
                 target_h = target_height_for_size(TaskSize.DOUBLE.value)
                 story.append(PageFillerFlowable(list(flowables), target_h))
                 idx += 1
+                had_sized_section = True
 
             else:
                 # Unknown size — fall through to free-flow
-                if not is_first_exercise:
+                if had_sized_section:
+                    story.append(PageBreak())
+                    had_sized_section = False
+                elif not is_first_exercise:
                     story.extend(section_divider())
                 story.extend(flowables)
                 idx += 1


### PR DESCRIPTION
Address first-user feedback on generated worksheets:

- Partition phrases between text-consuming exercises (reading, fill-blanks,
  text summary) so they never share the same sentences
- Improve reading comprehension questions to reference actual words from the
  passage instead of using generic templates
- Increase default reading passage length from 15 to 20 sentences
- Replace hard PageBreak with CondPageBreak after free-flow sections
  (grammar, vocab reference) to eliminate blank pages between sections
- Limit vocabulary reference table to 30 entries (max_entries param) so it
  fits on a single page even with info boxes appended

https://claude.ai/code/session_01N1AQ6uWr3vW7y6W9GhTMCQ