### PR TITLE
Make worksheet generation fully LLM-driven with learning path selection

### DIFF
--- a/.claude/commands/langwich.md
+++ b/.claude/commands/langwich.md
@@ -2,12 +2,12 @@ You are a friendly language learning assistant helping the user set up a persona
 
 ## How it works
 
-langwich has two modes for populating vocabulary:
+langwich is an **LLM-assistant-driven** language learning worksheet generator. The LLM (you) generates **all content** — vocabulary, grammar, reading passages, and complete exercise content. Python code handles only two things:
 
-1. **LLM mode (default)** — You (the AI assistant) generate the vocabulary, translations, CEFR levels, and example phrases directly, write them as JSON, and feed them to `langwich --from-json`. No external APIs or SpaCy needed. This is the recommended path.
-2. **Mining mode (optional)** — Uses SpaCy + web sources (Wikipedia, arXiv, etc.) to mine vocabulary automatically. Requires `pip install langwich[mining]`.
+1. **PDF rendering** — turning your generated content into a styled worksheet.
+2. **Task collection / retrieval** — storing vocabulary in a SQLite database for later reuse.
 
-Default to LLM mode. Only suggest mining mode if the user explicitly asks for automated corpus mining or already has the extras installed.
+There are no separate Python generator scripts. You are the generator.
 
 ## Step 1 — Mother tongue
 
@@ -93,7 +93,25 @@ Or describe your level in your own words (e.g. "I'm a total beginner").
 
 Accept free-form descriptions and map them to the closest CEFR level.
 
-## Step 5 — Grammar focus (optional)
+## Step 5 — Learning path
+
+Present the built-in learning paths and let the user choose:
+
+```
+Which learning path would you like?
+
+1. Balanced — a well-rounded mix of receptive and productive exercises (recommended)
+2. Vocabulary Focus — heavy on word work: matching, synonyms, fill-in-the-blanks, translation
+3. Reading First — comprehension-led: read a text first, then consolidate vocabulary
+4. Production — output-focused: creative writing, summaries, drawing
+5. Multimedia — incorporates video tasks and varied media
+
+Or describe your own preference (e.g. "mostly reading and writing, skip drawing").
+```
+
+If the user picks a named path, use `--path <name>`. If they describe a custom preference, build a custom exercise selection in Step 7.
+
+## Step 6 — Grammar focus (IMPORTANT — must produce real content)
 
 Suggest 2–4 grammar topics appropriate for the user's CEFR level and target language. For example:
 
@@ -110,7 +128,15 @@ Ask: "Would you like a grammar reference page? Here are some topics for your lev
 
 Be flexible — accept any grammar topic the user suggests, even if not in the table. If the user picks a topic, note it for the JSON generation step. If they say "skip", pass `--no-grammar-page` to the CLI.
 
-## Step 6 — Exercise selection
+**CRITICAL**: When the user chooses a grammar topic, you MUST generate a **complete grammar explanation** in the JSON `grammar.content` field. This means:
+- Clear rules explained in the learner's native language
+- Conjugation/declension tables where applicable (as formatted plain text)
+- 3–5 example sentences in the target language with translations
+- Common exceptions or pitfalls
+
+**NEVER** leave the grammar content as just a topic name, a placeholder, or an empty string. The grammar page on the worksheet will show whatever you put in `content` — if you leave it empty, the student gets a useless blank page.
+
+## Step 7 — Exercise selection
 
 Present the available exercise types and let the user choose which ones to include and how many items each. Show a numbered list like this:
 
@@ -127,11 +153,11 @@ Present the available exercise types and let the user choose which ones to inclu
 
 Ask: "Which exercises would you like? You can pick by number (e.g. 1, 2, 5) and optionally adjust the number of items (e.g. '1: 15, 5: 6'). Or just say 'all' for the full set."
 
-If the user says "all" or doesn't have a preference, use the **balanced** path. Otherwise, build a custom `LearningPath` from their selections. Always include Vocabulary Matching as the first exercise.
+If the user says "all" or doesn't have a preference, use the learning path chosen in Step 5. Otherwise, build a custom `LearningPath` from their selections. Always include Vocabulary Matching as the first exercise.
 
 When building a custom path, map the user's choices to a `--custom-exercises` CLI argument as a comma-separated list of `type:count` pairs. For example: `--custom-exercises vocab_matching:15,reading_comprehension:4,fill_blanks:10`
 
-## Step 7 — Confirm and generate
+## Step 8 — Confirm and generate
 
 Show a clear summary of what you collected:
 
@@ -140,6 +166,7 @@ Mother tongue  : <source_lang>
 Target language: <target_lang>
 Topics         : <domain1>, <domain2>, ...
 CEFR level     : <level>
+Learning path  : <path_name>
 Grammar focus  : <topic or "none">
 Exercises      : <exercise1> (<count>), <exercise2> (<count>), ...
 ```
@@ -148,9 +175,9 @@ Ask the user to confirm ("Does this look right? Type yes to generate, or tell me
 
 Once confirmed, generate the worksheet for each domain using these steps:
 
-### Generate vocabulary JSON
+### Generate the complete worksheet JSON
 
-For each domain, create a JSON file at `./data/<domain>_<source>_<target>.json` with the following structure. Use your own language knowledge to generate high-quality, domain-relevant vocabulary and example phrases at the requested CEFR level:
+For each domain, create a JSON file at `./data/<domain>_<source>_<target>.json`. You generate **everything** — vocabulary, grammar, reading passages, AND all exercise content. The Python code only renders your content to PDF.
 
 ```json
 {
@@ -176,7 +203,7 @@ For each domain, create a JSON file at `./data/<domain>_<source>_<target>.json` 
   ],
   "grammar": {
     "topic": "Present Tense",
-    "content": "Rules, conjugation tables, and examples for the grammar focus topic. Write clear explanations with 3-5 example sentences showing the rule in action. Use the target language for examples and the source language for explanations."
+    "content": "Full grammar explanation here — rules, tables, examples. See guidelines below."
   },
   "reading": {
     "passage": "A coherent, multi-paragraph reading text (see guidelines below).",
@@ -187,28 +214,74 @@ For each domain, create a JSON file at `./data/<domain>_<source>_<target>.json` 
       "Deep comprehension question 4",
       "Deep comprehension question 5"
     ]
+  },
+  "exercises": {
+    "vocab_matching": {
+      "items": [
+        {"number": 1, "term": "platform", "translation": "Bahnsteig"},
+        {"number": 2, "term": "departure", "translation": "Abfahrt"}
+      ]
+    },
+    "fill_blanks": {
+      "items": [
+        {"number": 1, "sentence": "The train ______ from platform 3.", "target": "departs"},
+        {"number": 2, "sentence": "Please check the ______ for delays.", "target": "schedule"}
+      ],
+      "word_bank": ["departs", "schedule", "passenger", "arrives"]
+    },
+    "synonyms": {
+      "items": [
+        {"number": 1, "term": "fast", "pos": "ADJ", "synonym": "quick", "antonym": "slow"},
+        {"number": 2, "term": "depart", "pos": "VERB", "synonym": "leave", "antonym": "arrive"}
+      ]
+    },
+    "translation": {
+      "items": [
+        {"number": 1, "source": "The train departs from platform 3."},
+        {"number": 2, "source": "Please buy your ticket before boarding."}
+      ]
+    },
+    "creative_writing": {
+      "prompt": "Write a short paragraph about a train journey using these words: platform, departure, passenger, schedule, arrive."
+    },
+    "text_summary": {
+      "passage": "A short text for the student to summarise (in the target language)."
+    },
+    "drawing_task": {
+      "prompt": "Draw a scene showing a busy train station. Label at least 5 items using vocabulary from this worksheet."
+    }
   }
 }
 ```
 
-Guidelines for generating vocabulary:
-- Include **20-30 vocabulary items** per domain, appropriate for the CEFR level.
+### Guidelines for vocabulary (MINIMUM 20 items)
+
+- Include **20–30 vocabulary items** per domain, appropriate for the CEFR level.
 - Mix parts of speech: mostly nouns and verbs, some adjectives and adverbs.
-- Provide **1-3 translations** per term (the most common ones).
-- Include **15-20 example phrases** that use the vocabulary in natural sentences.
+- Provide **1–3 translations** per term (the most common ones).
+- Include **15–20 example phrases** that use the vocabulary in natural sentences.
 - Every phrase must have a translation in the learner's native language.
 - Set `frequency` between 0.0 and 1.0 (higher = more common in the domain).
 - Terms and phrases should be genuinely useful for the domain, not generic filler.
 - Where it fits naturally, ground example phrases in real-world knowledge — reference a discovery, a finding, or an acclaimed work. A short citation like *(Pasteur, 1885)* or *(Nature, 2023)* is welcome when it feels natural, not forced.
 
-Guidelines for the grammar section:
-- Only include the `grammar` section if the user chose a grammar topic (didn't say "skip").
-- Write the `content` field as a clear, concise grammar explanation appropriate for the CEFR level.
-- Include conjugation/declension tables where relevant (as plain text).
-- Provide 3-5 example sentences in the target language with translations.
-- Keep explanations in the learner's native language (source_lang).
+**IMPORTANT**: The vocabulary array populates the **vocabulary reference table** at the end of the worksheet. This table shows every term with its translation in a two-column layout. If you only include 2–3 items, the vocabulary page will look empty. Always include at least 20 items.
 
-Guidelines for the reading section:
+### Guidelines for the grammar section (MANDATORY when chosen)
+
+When the user chose a grammar topic (did NOT say "skip"):
+- You **MUST** include the `grammar` section in the JSON.
+- The `content` field must contain a **complete, ready-to-print grammar explanation** — not a topic name, not a placeholder, not "Grammar notes will appear here."
+- Write the explanation in the learner's native language (source_lang).
+- Include conjugation/declension tables where relevant (as formatted plain text with alignment).
+- Provide 3–5 example sentences in the target language with translations.
+- Cover common exceptions and pitfalls.
+- The content should fill roughly half a page when rendered.
+
+When the user said "skip": omit the `grammar` key entirely from the JSON.
+
+### Guidelines for the reading section
+
 - Always include the `reading` section when the user's exercises include Reading Comprehension.
 - The `passage` must be a **proper, coherent, multi-paragraph text** — an article, report, essay, or narrative — NOT a collection of disconnected sentences.
 - Write the passage in the **target language** at the appropriate CEFR level.
@@ -232,6 +305,75 @@ Guidelines for the reading section:
 - Each question should require 2–3 sentences to answer properly.
 - Write questions in the **source language** (the learner's native language) so they understand what is being asked.
 - Do NOT use generic questions like "What is the main topic?" — every question must reference specific content from the passage.
+
+### Guidelines for the exercises section (YOU generate all content)
+
+The `exercises` object contains pre-generated content for every exercise the user chose. The Python code renders this content directly — there are no Python generator scripts.
+
+**vocab_matching**: Generate 10+ term–translation pairs. Pick items from your vocabulary list. The renderer will shuffle translations automatically.
+```json
+"vocab_matching": {
+  "items": [
+    {"number": 1, "term": "Bahnsteig", "translation": "platform"},
+    {"number": 2, "term": "Abfahrt", "translation": "departure"}
+  ]
+}
+```
+
+**fill_blanks**: Create 8+ sentences with one word blanked out. Each sentence should be natural and use vocabulary from the list. Provide a word bank.
+```json
+"fill_blanks": {
+  "items": [
+    {"number": 1, "sentence": "Der Zug ______ von Gleis 3 ab.", "target": "fährt"},
+    {"number": 2, "sentence": "Bitte prüfen Sie den ______ auf Verspätungen.", "target": "Fahrplan"}
+  ],
+  "word_bank": ["fährt", "Fahrplan", "Fahrgast", "kommt"]
+}
+```
+
+**synonyms**: For each term, provide a synonym and antonym (or leave antonym empty if none exists). Include the part of speech.
+```json
+"synonyms": {
+  "items": [
+    {"number": 1, "term": "schnell", "pos": "ADJ", "synonym": "rasch", "antonym": "langsam"},
+    {"number": 2, "term": "abfahren", "pos": "VERB", "synonym": "losfahren", "antonym": "ankommen"}
+  ]
+}
+```
+
+**translation**: Provide 6–8 sentences to translate. Write them in the target language (the student translates to their native language).
+```json
+"translation": {
+  "items": [
+    {"number": 1, "source": "Der Zug fährt von Gleis 3 ab."},
+    {"number": 2, "source": "Bitte kaufen Sie Ihr Ticket vor dem Einsteigen."}
+  ]
+}
+```
+
+**creative_writing**: Write a specific, engaging writing prompt that references the domain and lists vocabulary words to use.
+```json
+"creative_writing": {
+  "prompt": "Write a short paragraph about a train journey...",
+  "vocab_required": ["Bahnsteig", "Abfahrt", "Fahrgast", "Fahrplan", "ankommen"]
+}
+```
+
+**text_summary**: Provide a passage in the target language for the student to summarise. This should be different from the reading comprehension passage.
+```json
+"text_summary": {
+  "passage": "A short informative text in the target language (150-250 words)."
+}
+```
+
+**drawing_task**: Write a specific drawing prompt that incorporates vocabulary.
+```json
+"drawing_task": {
+  "prompt": "Draw a scene showing a busy train station. Label at least 5 items using vocabulary from this worksheet."
+}
+```
+
+Only include exercise keys for exercises the user actually selected. Every exercise the user chose MUST have its content fully generated here.
 
 ### Build the worksheet
 
@@ -258,16 +400,7 @@ If `langwich` is not installed yet, help the user set it up:
 pip install -e .
 ```
 
-That's it. The core installation needs only Python 3.11+ and four lightweight packages (reportlab, sqlalchemy, pydantic, pydantic-settings). No SpaCy download, no API keys, no `.env` file required for the default LLM mode.
-
-If the user wants the full mining pipeline (SpaCy + web source extraction), they can run:
-
-```bash
-pip install -e ".[mining]"
-python -m spacy download en_core_web_sm
-```
-
-Then use `langwich --domain <slug> --source-lang <code> --target-lang <code> --level <CEFR> --path balanced` instead of `--from-json`.
+That's it. The core installation needs only Python 3.11+ and four lightweight packages (reportlab, sqlalchemy, pydantic, pydantic-settings). No SpaCy download, no API keys, no `.env` file required.
 
 ## Interaction format — STRICT
 

--- a/src/langwich/db/manager.py
+++ b/src/langwich/db/manager.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.engine import Engine
@@ -73,6 +73,9 @@ class DomainDatabase:
         # Optional reading comprehension content (populated from JSON import)
         self.reading_passage: str | None = None
         self.reading_questions: list[str] | None = None
+
+        # Pre-generated exercise content from LLM (populated from JSON import)
+        self.exercises: dict[str, Any] | None = None
 
     # ── Lifecycle ────────────────────────────────────────────────────
 

--- a/src/langwich/exercises/creative_writing.py
+++ b/src/langwich/exercises/creative_writing.py
@@ -28,6 +28,19 @@ class CreativeWritingExercise(Exercise):
         phrases: list[PhraseEntry],
         level: CEFRLevel,
     ) -> ExerciseContent:
+        # ── Prefer LLM-generated content ────────────────────────────
+        llm = self.config.get("llm_content")
+        if llm and llm.get("prompt"):
+            vocab_required = llm.get("vocab_required", [])
+            return ExerciseContent(
+                title="Creative Writing",
+                instructions=llm["prompt"],
+                items=[{"vocab_required": vocab_required}],
+                solution=[],
+                metadata={"level": level.value, "line_count": self.config.get("line_count", 10)},
+            )
+
+        # ── Fallback: generate from database vocabulary ─────────────
         num_vocab = self.config.get("num_vocab_to_use", 5)
         domain = self.config.get("domain", "").replace("-", " ") or "this topic"
         target_words = random.sample(vocabulary, min(num_vocab, len(vocabulary)))

--- a/src/langwich/exercises/drawing_task.py
+++ b/src/langwich/exercises/drawing_task.py
@@ -29,6 +29,21 @@ class DrawingTaskExercise(Exercise):
         phrases: list[PhraseEntry],
         level: CEFRLevel,
     ) -> ExerciseContent:
+        # ── Prefer LLM-generated content ────────────────────────────
+        llm = self.config.get("llm_content")
+        if llm and llm.get("prompt"):
+            return ExerciseContent(
+                title="Drawing Task",
+                instructions=llm["prompt"],
+                items=[],
+                solution=[],
+                metadata={
+                    "level": level.value,
+                    "box_height_cm": self.config.get("box_height_cm", 8),
+                },
+            )
+
+        # ── Fallback: generate from database vocabulary ─────────────
         terms = [v.term for v in vocabulary[:5]]
         prompts = [
             f"Draw a scene that includes: {', '.join(terms)}.",

--- a/src/langwich/exercises/fill_blanks.py
+++ b/src/langwich/exercises/fill_blanks.py
@@ -32,6 +32,22 @@ class FillBlanksExercise(Exercise):
         phrases: list[PhraseEntry],
         level: CEFRLevel,
     ) -> ExerciseContent:
+        # ── Prefer LLM-generated content ────────────────────────────
+        llm = self.config.get("llm_content")
+        if llm and llm.get("items"):
+            items = llm["items"]
+            word_bank = llm.get("word_bank", [t["target"] for t in items])
+            random.shuffle(word_bank)
+            solutions = [{"number": it["number"], "answer": it["target"]} for it in items]
+            return ExerciseContent(
+                title="Fill in the Blanks",
+                instructions="Complete each sentence with the correct word from the word bank.",
+                items=items,
+                solution=solutions,
+                metadata={"level": level.value, "word_bank": word_bank},
+            )
+
+        # ── Fallback: generate from database phrases ────────────────
         num_items = self.config.get("num_items", 8)
 
         # Deduplicate phrases by text to avoid identical blanked sentences.
@@ -43,9 +59,9 @@ class FillBlanksExercise(Exercise):
                 usable_phrases.append(p)
         selected = random.sample(usable_phrases, min(num_items, len(usable_phrases)))
 
-        items: list[dict[str, Any]] = []
-        solutions: list[dict[str, Any]] = []
-        word_bank: list[str] = []
+        items_fb: list[dict[str, Any]] = []
+        solutions_fb: list[dict[str, Any]] = []
+        word_bank_fb: list[str] = []
         used_targets: set[str] = set()
 
         for i, phrase in enumerate(selected, 1):
@@ -62,18 +78,18 @@ class FillBlanksExercise(Exercise):
             blanked = re.sub(
                 re.escape(target), "_" * max(len(target), 6), phrase.text, count=1
             )
-            items.append({"number": i, "sentence": blanked, "target": target})
-            solutions.append({"number": i, "answer": target})
-            word_bank.append(target)
+            items_fb.append({"number": i, "sentence": blanked, "target": target})
+            solutions_fb.append({"number": i, "answer": target})
+            word_bank_fb.append(target)
 
-        random.shuffle(word_bank)
+        random.shuffle(word_bank_fb)
 
         return ExerciseContent(
             title="Fill in the Blanks",
             instructions="Complete each sentence with the correct word from the word bank.",
-            items=items,
-            solution=solutions,
-            metadata={"level": level.value, "word_bank": word_bank},
+            items=items_fb,
+            solution=solutions_fb,
+            metadata={"level": level.value, "word_bank": word_bank_fb},
         )
 
     def render(self, content: ExerciseContent) -> list[Flowable]:

--- a/src/langwich/exercises/reading.py
+++ b/src/langwich/exercises/reading.py
@@ -46,8 +46,9 @@ class ReadingComprehensionExercise(Exercise):
         num_questions = self.config.get("num_questions", 5)
 
         # ── Prefer LLM-generated content from the JSON ───────────────
-        passage = self.config.get("reading_passage") or ""
-        questions: list[str] = self.config.get("reading_questions") or []
+        llm = self.config.get("llm_content")
+        passage = (llm or {}).get("passage") or self.config.get("reading_passage") or ""
+        questions: list[str] = (llm or {}).get("questions") or self.config.get("reading_questions") or []
 
         # ── Fallback: assemble passage from phrases ──────────────────
         if not passage:

--- a/src/langwich/exercises/synonyms.py
+++ b/src/langwich/exercises/synonyms.py
@@ -28,15 +28,6 @@ class SynonymsExercise(Exercise):
         phrases: list[PhraseEntry],
         level: CEFRLevel,
     ) -> ExerciseContent:
-        num_items = self.config.get("num_items", 6)
-        selected = random.sample(vocabulary, min(num_items, len(vocabulary)))
-
-        items = [
-            {"number": i, "term": v.term, "pos": v.part_of_speech.value}
-            for i, v in enumerate(selected, 1)
-        ]
-
-        # Adapt task complexity to CEFR level.
         is_beginner = level in (CEFRLevel.A1, CEFRLevel.A2)
 
         if is_beginner:
@@ -49,6 +40,26 @@ class SynonymsExercise(Exercise):
         else:
             title = "Synonyms & Antonyms"
             instructions = "Write one synonym and one antonym for each word."
+
+        # ── Prefer LLM-generated content ────────────────────────────
+        llm = self.config.get("llm_content")
+        if llm and llm.get("items"):
+            return ExerciseContent(
+                title=title,
+                instructions=instructions,
+                items=llm["items"],
+                solution=[],
+                metadata={"level": level.value, "is_beginner": is_beginner},
+            )
+
+        # ── Fallback: generate from database vocabulary ─────────────
+        num_items = self.config.get("num_items", 6)
+        selected = random.sample(vocabulary, min(num_items, len(vocabulary)))
+
+        items = [
+            {"number": i, "term": v.term, "pos": v.part_of_speech.value}
+            for i, v in enumerate(selected, 1)
+        ]
 
         return ExerciseContent(
             title=title,

--- a/src/langwich/exercises/text_summary.py
+++ b/src/langwich/exercises/text_summary.py
@@ -28,6 +28,22 @@ class TextSummaryExercise(Exercise):
         phrases: list[PhraseEntry],
         level: CEFRLevel,
     ) -> ExerciseContent:
+        # ── Prefer LLM-generated content ────────────────────────────
+        llm = self.config.get("llm_content")
+        if llm and llm.get("passage"):
+            return ExerciseContent(
+                title="Text Summary",
+                instructions="Read the text below and write a summary in 2\u20133 sentences. Focus on the key facts and any evidence presented.",
+                items=[],
+                solution=[],
+                metadata={
+                    "level": level.value,
+                    "passage": llm["passage"],
+                    "summary_lines": self.config.get("summary_lines", 5),
+                },
+            )
+
+        # ── Fallback: assemble from database phrases ────────────────
         max_sentences = self.config.get("max_passage_sentences", 10)
         passage_phrases = random.sample(phrases, min(max_sentences, len(phrases)))
         passage = " ".join(p.text for p in passage_phrases)

--- a/src/langwich/exercises/translation.py
+++ b/src/langwich/exercises/translation.py
@@ -28,11 +28,24 @@ class TranslationExercise(Exercise):
         phrases: list[PhraseEntry],
         level: CEFRLevel,
     ) -> ExerciseContent:
+        direction = self.config.get("direction", "forward")
+
+        # ── Prefer LLM-generated content ────────────────────────────
+        llm = self.config.get("llm_content")
+        if llm and llm.get("items"):
+            return ExerciseContent(
+                title="Translation",
+                instructions="Translate each sentence.",
+                items=llm["items"],
+                solution=[],
+                metadata={"level": level.value, "direction": direction},
+            )
+
+        # ── Fallback: generate from database phrases ────────────────
         num_items = self.config.get("num_items", 6)
         translatable = [p for p in phrases if p.translation]
         selected = random.sample(translatable, min(num_items, len(translatable)))
 
-        direction = self.config.get("direction", "forward")
         items = []
         solutions = []
         for i, phrase in enumerate(selected, 1):

--- a/src/langwich/exercises/vocab_matching.py
+++ b/src/langwich/exercises/vocab_matching.py
@@ -140,32 +140,51 @@ class VocabMatchingExercise(Exercise):
         phrases: list[PhraseEntry],
         level: CEFRLevel,
     ) -> ExerciseContent:
+        # ── Prefer LLM-generated content ────────────────────────────
+        llm = self.config.get("llm_content")
+        if llm and llm.get("items"):
+            items = llm["items"]
+            solutions = [{"number": it["number"], "term": it["term"], "answer": it["translation"]} for it in items]
+            # Shuffle translations for the student version
+            translation_list = [it["translation"] for it in items]
+            random.shuffle(translation_list)
+            for i, item in enumerate(items):
+                item["shuffled_translation"] = translation_list[i]
+            return ExerciseContent(
+                title="Vocabulary Matching",
+                instructions="Draw a line from each term on the left to its translation on the right.",
+                items=items,
+                solution=solutions,
+                metadata={"level": level.value},
+            )
+
+        # ── Fallback: generate from database vocabulary ─────────────
         num_items = self.config.get("num_items", 10)
         selected = random.sample(vocabulary, min(num_items, len(vocabulary)))
 
-        items: list[dict[str, Any]] = []
-        solutions: list[dict[str, Any]] = []
+        items_fb: list[dict[str, Any]] = []
+        solutions_fb: list[dict[str, Any]] = []
         for i, entry in enumerate(selected, 1):
             translations = json.loads(entry.translations_json) if entry.translations_json else ["—"]
-            items.append({
+            items_fb.append({
                 "number": i,
                 "term": entry.term,
                 "translation": translations[0] if translations else "—",
             })
-            solutions.append({"number": i, "term": entry.term, "answer": translations[0]})
+            solutions_fb.append({"number": i, "term": entry.term, "answer": translations[0]})
 
         # Shuffle translations for the student version
         if self.config.get("shuffle_translations", True):
-            translation_list = [it["translation"] for it in items]
+            translation_list = [it["translation"] for it in items_fb]
             random.shuffle(translation_list)
-            for i, item in enumerate(items):
+            for i, item in enumerate(items_fb):
                 item["shuffled_translation"] = translation_list[i]
 
         return ExerciseContent(
             title="Vocabulary Matching",
             instructions="Draw a line from each term on the left to its translation on the right.",
-            items=items,
-            solution=solutions,
+            items=items_fb,
+            solution=solutions_fb,
             metadata={"level": level.value},
         )
 

--- a/src/langwich/exercises/youtube_task.py
+++ b/src/langwich/exercises/youtube_task.py
@@ -30,6 +30,21 @@ class YouTubeTaskExercise(Exercise):
         video_url = self.config.get("video_url", "")
         num_questions = self.config.get("num_questions", 3)
 
+        # ── Prefer LLM-generated content ────────────────────────────
+        llm = self.config.get("llm_content")
+        if llm:
+            url = llm.get("video_url", video_url)
+            questions = llm.get("questions", [])[:num_questions]
+            items = [{"number": i, "question": q} for i, q in enumerate(questions, 1)]
+            return ExerciseContent(
+                title="Video Comprehension",
+                instructions=f"Watch the video, then answer the questions.\n{url}",
+                items=items,
+                solution=[],
+                metadata={"level": level.value, "video_url": url},
+            )
+
+        # ── Fallback: generic questions ─────────────────────────────
         questions = [
             "What is the main topic of the video?",
             "List three new words you heard.",

--- a/src/langwich/generator.py
+++ b/src/langwich/generator.py
@@ -183,12 +183,18 @@ class WorksheetGenerator:
             # Use the partitioned phrase pool for text exercises, full set otherwise
             step_phrases = phrase_pools.get(id(step), phrases)
 
-            # Inject domain context into exercise config so prompts can reference it.
+            # Inject domain context and pre-generated content into exercise config.
             exercise_config = {**step.config, "domain": self.db.domain}
             if self.db.reading_passage:
                 exercise_config["reading_passage"] = self.db.reading_passage
             if self.db.reading_questions:
                 exercise_config["reading_questions"] = self.db.reading_questions
+
+            # Pass pre-generated exercise content from LLM (if available)
+            if self.db.exercises:
+                ex_key = step.exercise_type.value
+                if ex_key in self.db.exercises:
+                    exercise_config["llm_content"] = self.db.exercises[ex_key]
             exercise = exercise_cls(config=exercise_config)
             try:
                 content = exercise.generate(vocabulary, step_phrases, self.level)

--- a/src/langwich/import_data.py
+++ b/src/langwich/import_data.py
@@ -142,6 +142,11 @@ def import_json(
         db.reading_passage = reading.get("passage", "")
         db.reading_questions = reading.get("questions", [])
 
+    # Pre-generated exercise content (LLM-driven workflow)
+    exercises = data.get("exercises")
+    if exercises:
+        db.exercises = exercises
+
     logger.info(
         "Imported %d vocabulary + %d phrases into %s",
         vocab_count, phrase_count, db.db_path,

--- a/src/langwich/rendering/components.py
+++ b/src/langwich/rendering/components.py
@@ -145,12 +145,21 @@ def grammar_reference_page(
     if content:
         flowables.extend(info_box(content, min_height=200))
     elif topic:
-        flowables.extend(info_box(topic, min_height=200))
+        # topic without content — render a warning so it's obvious something is missing
+        flowables.extend(
+            info_box(
+                f"<b>{topic_display}</b><br/><br/>"
+                "Grammar content was not provided. Regenerate the worksheet JSON "
+                "with a complete grammar explanation in the \"grammar.content\" field.",
+                min_height=200,
+            )
+        )
     else:
         flowables.extend(
             info_box(
-                "Grammar notes will appear here. Add a \"grammar\" section to "
-                "your JSON with \"topic\" and \"content\" fields.",
+                "Grammar content was not provided. Add a \"grammar\" section to "
+                "your JSON with \"topic\" and \"content\" fields, or pass "
+                "--no-grammar-page to skip this section.",
             )
         )
 


### PR DESCRIPTION
- Add learning path selection step (Step 5) to the langwich workflow so
  users are always asked which path they prefer
- Strengthen grammar requirements: content field is now mandatory when a
  topic is chosen — no more placeholder pages
- Expand JSON schema with an "exercises" object where the LLM generates
  all exercise content (vocab matching items, fill-blank sentences,
  synonyms, translation items, writing prompts, etc.)
- All 8 exercise classes now prefer LLM-generated content from
  config["llm_content"] and only fall back to random DB generation
  when no pre-generated content is available
- Require minimum 20 vocabulary items to ensure the reference table
  is properly populated
- Improve grammar page rendering: show clear warning when content is
  missing instead of a vague placeholder
- Update import_data.py and DomainDatabase to pass pre-generated
  exercise data through the pipeline

https://claude.ai/code/session_01QA6JHPEisYxGv8zLUxmC5V