### PR TITLE
Fix onboarding gap: document full JSON schema, add example, mark unimplemented exercises

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,23 @@ Requires Python 3.11+ and four packages: reportlab, sqlalchemy, pydantic, pydant
 
 langwich is LLM-driven. Claude generates **all content** (vocabulary, grammar, reading passages, exercise items). Python handles only PDF rendering and database storage. There are no separate generator scripts.
 
+**Important for LLM agents outside Claude Code:** The complete JSON schema, content generation guidelines, and per-exercise content format are documented in two places:
+1. **[`README.md`](README.md)** — full JSON schema with field reference and a working example
+2. **[`.claude/commands/langwich.md`](.claude/commands/langwich.md)** — detailed content guidelines (grammar quality, reading passage length by CEFR level, exercise item formats)
+3. **[`examples/film_de_fr.json`](examples/film_de_fr.json)** — a complete, working example JSON that produces a valid worksheet
+
+Read these files before generating any JSON. The Python code does **not** generate content — if your JSON is missing `grammar`, `reading`, or `exercises` sections, those parts of the worksheet will be empty or use low-quality fallbacks.
+
 ### Workflow
 
-1. User runs `/langwich`
+1. User runs `/langwich` (or an LLM generates JSON directly)
 2. Claude guides through setup: native language, target language, topics, CEFR level, learning path, grammar focus, exercise selection
 3. Claude generates a JSON file at `./data/<domain>_<source>_<target>.json` with vocabulary, phrases, grammar, reading passages, and exercise content
 4. Claude runs `langwich --from-json <file> --level <CEFR> --path <path>` to render the PDF
+
+### Only 9 of 35 exercise types are currently implemented
+
+The `ExerciseType` enum defines 35 types, but only these 9 have Python rendering classes: `vocab_matching`, `fill_blanks`, `synonyms`, `translation`, `reading_comprehension`, `creative_writing`, `text_summary`, `youtube_task`, `drawing_task`. The remaining 26 are planned but will be skipped with a warning. Stick to the implemented types when generating worksheets.
 
 ## Project structure
 
@@ -33,11 +44,12 @@ langwich is LLM-driven. Claude generates **all content** (vocabulary, grammar, r
   - `generator.py` — CLI entry point and WorksheetGenerator
   - `import_data.py` — JSON vocabulary import
   - `db/` — SQLAlchemy models and per-domain database manager
-  - `exercises/` — exercise type implementations (35 types)
+  - `exercises/` — exercise type implementations (9 implemented, 26 planned)
   - `paths/` — learning path templates
   - `rendering/` — Cupertino-style PDF renderer
   - `mining/` — optional corpus mining pipeline (requires `pip install -e ".[mining]"`)
-- `.claude/commands/langwich.md` — the `/langwich` slash command definition
+- `.claude/commands/langwich.md` — the `/langwich` slash command definition (detailed content guidelines)
+- `examples/` — working example JSON files
 - `data/` — generated JSON and PDF output directory
 
 ## CLI reference

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ langwich --domain railway-operations --source-lang en --target-lang de --level B
 ## Features
 
 - **Domain-specific vocabulary**: Separate SQLite databases per domain+language combo
-- **35 exercise types** across 9 categories (see below)
+- **9 implemented exercise types** (26 more planned) across 9 categories (see below)
 - **5+ learning paths**: Vocabulary Focus, Reading First, Balanced, Production, Multimedia, and more
 - **CEFR levels**: A1 through C2, with level-appropriate content selection
 - **Cupertino-style PDFs**: Clean Helvetica typography, high contrast, e-paper optimised
@@ -70,110 +70,175 @@ langwich --domain railway-operations --source-lang en --target-lang de --level B
 
 ---
 
-## Exercise Types (35)
+## Exercise Types
 
-### Core Vocabulary & Grammar
+### Implemented (9 types — ready to use)
+
 | Type | Size | CEFR | Description |
 |------|------|------|-------------|
 | `vocab_matching` | Half | A1+ | Match terms to translations |
 | `fill_blanks` | Half | A1+ | Complete sentences with missing words from word bank |
 | `synonyms` | Half | A1+ | Write synonyms and antonyms for terms |
-| `opposites` | Half | A1+ | Write antonyms / match opposites |
 | `translation` | Half | A1+ | Translate sentences between languages |
-| `word_stems` | Half | A2+ | Conjugation and declination tables |
-
-### Reading & Text Analysis
-| Type | Size | CEFR | Description |
-|------|------|------|-------------|
 | `reading_comprehension` | Double | A2+ | Read a passage, answer comprehension questions |
+| `creative_writing` | Full | A2+ | Open-ended writing prompts using target vocabulary |
 | `text_summary` | Full | A2+ | Summarise a passage in 2–3 sentences |
-| `word_marking` | Half | A2+ | Mark specific word categories (attributive, localization, temporal, modal) in a text |
-| `cloze_text` | Full | B1+ | Classic cloze test — every nth word removed |
+| `youtube_task` | Full | A2+ | Video comprehension with URL/QR code and questions |
+| `drawing_task` | Half | A1+ | Visual sketch or diagram in response to a prompt |
 
-### Text Production (Genres)
+### Planned (26 types — not yet implemented, will be skipped with a warning)
+
+<details>
+<summary>Click to expand planned exercise types</summary>
+
 | Type | Size | CEFR | Description |
 |------|------|------|-------------|
-| `creative_writing` | Full | A2+ | Open-ended writing prompts using target vocabulary |
+| `opposites` | Half | A1+ | Write antonyms / match opposites |
+| `word_stems` | Half | A2+ | Conjugation and declination tables |
+| `word_marking` | Half | A2+ | Mark specific word categories in a text |
+| `cloze_text` | Full | B1+ | Classic cloze test — every nth word removed |
 | `poetry_writing` | Full | A2+ | Write a poem (acrostic, haiku, limerick, free verse) |
-| `news_headline` | Full | A2+ | Write newspaper headlines and lead paragraphs (or academic abstracts) |
+| `news_headline` | Full | A2+ | Write newspaper headlines and lead paragraphs |
 | `press_release` | Full | B1+ | Write a press release with structured template |
 | `job_application` | Full | B1+ | Write a formal cover letter responding to a job ad |
 | `blog_post` | Full | A2+ | Write an informal blog post with personal opinion |
-| `movie_review` | Full | A2+ | Write a review (movie, book, restaurant, product) with rating |
+| `movie_review` | Full | A2+ | Write a review (movie, book, restaurant, product) |
 | `text_transformation` | Full | B1+ | Rewrite a text changing register, tense, person, or voice |
-
-### Conversation & Dialogue
-| Type | Size | CEFR | Description |
-|------|------|------|-------------|
-| `conversation` | Full | A1+ | Complete or write a dialogue (gap-fill, free, or role-play modes) |
-
-### Puzzles & Games
-| Type | Size | CEFR | Description |
-|------|------|------|-------------|
+| `conversation` | Full | A1+ | Complete or write a dialogue |
 | `word_search` | Half | A1+ | Find vocabulary words hidden in a letter grid |
 | `crossword` | Full | A1+ | Crossword puzzle — clues are translations or definitions |
 | `odd_one_out` | Half | A1+ | Identify which word doesn't belong in a group |
 | `sentence_reorder` | Half | A1+ | Arrange scrambled words into correct sentence order |
-
-### Numbers, Time & Calculation
-| Type | Size | CEFR | Description |
-|------|------|------|-------------|
 | `time_and_date` | Half | A1+ | Tell time, read schedules, write dates |
 | `number_tasks` | Half | A1+ | Telephone numbers, years, prices, technology specs |
 | `calculation` | Half | A1+ | Math word problems in the target language |
 | `statistics` | Full | B1+ | Read charts, calculate percentages, interpret data |
-
-### Real-World Texts
-| Type | Size | CEFR | Description |
-|------|------|------|-------------|
 | `recipe` | Full | A2+ | Read, write, or reorder recipe steps |
 | `walkthrough` | Full | A2+ | Write step-by-step instructions / how-to guide |
-
-### Listening & Media
-| Type | Size | CEFR | Description |
-|------|------|------|-------------|
-| `youtube_task` | Full | A2+ | Video comprehension with URL/QR code and questions |
-| `listening_steps` | Full | A2+ | Segmented YouTube listening with timestamps and step-by-step questions |
-
-### Visual & Preparation
-| Type | Size | CEFR | Description |
-|------|------|------|-------------|
-| `drawing_task` | Half | A1+ | Visual sketch or diagram in response to a prompt |
+| `listening_steps` | Full | A2+ | Segmented YouTube listening with timestamps |
 | `dictation_prep` | Half | A1+ | Practice writing words before a dictation |
 | `error_correction` | Half | A2+ | Find and correct deliberate mistakes in sentences |
+
+</details>
 
 ---
 
 ## JSON Format
 
-The `--from-json` input uses this structure:
+The `--from-json` input uses this structure. **All content must be pre-generated by the caller** (you, or an LLM agent). The Python code only renders the content to PDF — it does not generate vocabulary, grammar, reading passages, or exercise items.
+
+A complete working example is available at [`examples/film_de_fr.json`](examples/film_de_fr.json). Run it with:
+
+```bash
+langwich --from-json examples/film_de_fr.json --level A2 --path balanced
+```
+
+### Full schema
 
 ```json
 {
-  "domain": "railway-operations",
-  "source_lang": "en",
-  "target_lang": "de",
+  "domain": "film",
+  "source_lang": "de",
+  "target_lang": "fr",
+
   "vocabulary": [
     {
-      "term": "platform",
-      "lemma": "platform",
+      "term": "le film",
+      "lemma": "film",
       "pos": "NOUN",
-      "cefr": "A2",
-      "translations": ["Bahnsteig", "Gleis"],
-      "frequency": 0.85
+      "cefr": "A1",
+      "translations": ["der Film"],
+      "frequency": 0.95
     }
   ],
+
   "phrases": [
     {
-      "text": "The train departs from platform 3.",
-      "translation": "Der Zug faehrt von Gleis 3 ab.",
+      "text": "Ce film a remporté la Palme d'or.",
+      "translation": "Dieser Film hat die Goldene Palme gewonnen.",
       "cefr": "A2"
     }
-  ]
+  ],
+
+  "grammar": {
+    "topic": "Le passé composé",
+    "content": "Complete grammar explanation here — rules, conjugation tables, 3-5 example sentences with translations, common exceptions. This text is rendered directly onto the grammar page. If left empty, the page will be blank."
+  },
+
+  "reading": {
+    "passage": "A coherent, multi-paragraph reading text in the target language (120-700 words depending on CEFR level). This is NOT a list of sentences — it must be a proper article, essay, or narrative with paragraph structure.",
+    "questions": [
+      "Comprehension question 1 (in the learner's native language)",
+      "Comprehension question 2",
+      "Comprehension question 3",
+      "Comprehension question 4",
+      "Comprehension question 5"
+    ]
+  },
+
+  "exercises": {
+    "vocab_matching": {
+      "items": [
+        {"number": 1, "term": "le réalisateur", "translation": "der Regisseur"},
+        {"number": 2, "term": "le scénario", "translation": "das Drehbuch"}
+      ]
+    },
+    "fill_blanks": {
+      "items": [
+        {"number": 1, "sentence": "Le ______ a tourné ce film.", "target": "réalisateur"}
+      ],
+      "word_bank": ["réalisateur", "scénario", "film"]
+    },
+    "synonyms": {
+      "items": [
+        {"number": 1, "term": "émouvant", "pos": "ADJ", "synonym": "touchant", "antonym": "indifférent"}
+      ]
+    },
+    "translation": {
+      "items": [
+        {"number": 1, "source": "Ce film a remporté la Palme d'or."}
+      ]
+    },
+    "reading_comprehension": {
+      "passage": "Optional: overrides the top-level reading.passage for this exercise",
+      "questions": ["Optional: overrides reading.questions"]
+    },
+    "creative_writing": {
+      "prompt": "Write a short paragraph about...",
+      "vocab_required": ["word1", "word2"]
+    },
+    "text_summary": {
+      "passage": "A short text (150-250 words) for the student to summarise."
+    },
+    "youtube_task": {
+      "video_url": "https://www.youtube.com/watch?v=...",
+      "questions": ["Question about the video"]
+    },
+    "drawing_task": {
+      "prompt": "Draw a scene showing..."
+    }
+  }
 }
 ```
 
-Fields: `term` (required), `lemma` (defaults to lowercase term), `pos` (NOUN/VERB/ADJ/ADV/OTHER), `cefr` (A1-C2), `translations` (list of strings), `frequency` (0.0-1.0).
+### Field reference
+
+**Top-level fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `domain` | Yes | Short slug for the topic (e.g. `"film"`, `"railway-operations"`) |
+| `source_lang` | No | Learner's native language ISO code (default: `"en"`) |
+| `target_lang` | No | Target language ISO code (default: `"de"`) |
+| `vocabulary` | Yes | Array of 20+ vocabulary items (populates the reference table) |
+| `phrases` | Yes | Array of 15+ example sentences with translations |
+| `grammar` | No | Grammar reference page content (omit to skip, or use `--no-grammar-page`) |
+| `reading` | No | Reading comprehension passage and questions |
+| `exercises` | No | Pre-generated content for each exercise type |
+
+**Vocabulary item fields:** `term` (required), `lemma` (defaults to lowercase term), `pos` (NOUN/VERB/ADJ/ADV/PREP/CONJ/PRON/DET/OTHER), `cefr` (A1-C2), `translations` (list of strings), `frequency` (0.0-1.0).
+
+**Important:** The `vocabulary` array populates the vocabulary reference table at the end of the worksheet. Include at least 20 items or the page will look empty. The `grammar.content` field is rendered directly — it must contain a complete explanation, not just a topic name. The `reading.passage` must be a coherent multi-paragraph text, not disconnected sentences.
 
 ---
 

--- a/examples/film_de_fr.json
+++ b/examples/film_de_fr.json
@@ -1,0 +1,393 @@
+{
+  "domain": "film",
+  "source_lang": "de",
+  "target_lang": "fr",
+  "vocabulary": [
+    {
+      "term": "le film",
+      "lemma": "film",
+      "pos": "NOUN",
+      "cefr": "A1",
+      "translations": ["der Film"],
+      "frequency": 0.95
+    },
+    {
+      "term": "le réalisateur",
+      "lemma": "réalisateur",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["der Regisseur"],
+      "frequency": 0.82
+    },
+    {
+      "term": "la réalisatrice",
+      "lemma": "réalisatrice",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["die Regisseurin"],
+      "frequency": 0.75
+    },
+    {
+      "term": "l'acteur",
+      "lemma": "acteur",
+      "pos": "NOUN",
+      "cefr": "A1",
+      "translations": ["der Schauspieler"],
+      "frequency": 0.90
+    },
+    {
+      "term": "l'actrice",
+      "lemma": "actrice",
+      "pos": "NOUN",
+      "cefr": "A1",
+      "translations": ["die Schauspielerin"],
+      "frequency": 0.88
+    },
+    {
+      "term": "le scénario",
+      "lemma": "scénario",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["das Drehbuch"],
+      "frequency": 0.78
+    },
+    {
+      "term": "tourner",
+      "lemma": "tourner",
+      "pos": "VERB",
+      "cefr": "A2",
+      "translations": ["drehen", "filmen"],
+      "frequency": 0.80
+    },
+    {
+      "term": "le tournage",
+      "lemma": "tournage",
+      "pos": "NOUN",
+      "cefr": "B1",
+      "translations": ["die Dreharbeiten"],
+      "frequency": 0.65
+    },
+    {
+      "term": "la scène",
+      "lemma": "scène",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["die Szene"],
+      "frequency": 0.85
+    },
+    {
+      "term": "le personnage",
+      "lemma": "personnage",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["die Figur", "die Rolle"],
+      "frequency": 0.82
+    },
+    {
+      "term": "l'écran",
+      "lemma": "écran",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["die Leinwand", "der Bildschirm"],
+      "frequency": 0.78
+    },
+    {
+      "term": "la bande-annonce",
+      "lemma": "bande-annonce",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["der Trailer", "der Vorschau"],
+      "frequency": 0.70
+    },
+    {
+      "term": "le sous-titre",
+      "lemma": "sous-titre",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["der Untertitel"],
+      "frequency": 0.72
+    },
+    {
+      "term": "la séance",
+      "lemma": "séance",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["die Vorstellung", "die Vorführung"],
+      "frequency": 0.68
+    },
+    {
+      "term": "le cinéma",
+      "lemma": "cinéma",
+      "pos": "NOUN",
+      "cefr": "A1",
+      "translations": ["das Kino"],
+      "frequency": 0.92
+    },
+    {
+      "term": "le genre",
+      "lemma": "genre",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["das Genre", "die Gattung"],
+      "frequency": 0.75
+    },
+    {
+      "term": "la comédie",
+      "lemma": "comédie",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["die Komödie"],
+      "frequency": 0.78
+    },
+    {
+      "term": "le drame",
+      "lemma": "drame",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["das Drama"],
+      "frequency": 0.76
+    },
+    {
+      "term": "le documentaire",
+      "lemma": "documentaire",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["der Dokumentarfilm"],
+      "frequency": 0.72
+    },
+    {
+      "term": "la critique",
+      "lemma": "critique",
+      "pos": "NOUN",
+      "cefr": "B1",
+      "translations": ["die Kritik", "die Rezension"],
+      "frequency": 0.70
+    },
+    {
+      "term": "le spectateur",
+      "lemma": "spectateur",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["der Zuschauer"],
+      "frequency": 0.74
+    },
+    {
+      "term": "la spectatrice",
+      "lemma": "spectatrice",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["die Zuschauerin"],
+      "frequency": 0.68
+    },
+    {
+      "term": "émouvant",
+      "lemma": "émouvant",
+      "pos": "ADJ",
+      "cefr": "A2",
+      "translations": ["bewegend", "ergreifend"],
+      "frequency": 0.65
+    },
+    {
+      "term": "captivant",
+      "lemma": "captivant",
+      "pos": "ADJ",
+      "cefr": "B1",
+      "translations": ["fesselnd", "packend"],
+      "frequency": 0.62
+    },
+    {
+      "term": "décevant",
+      "lemma": "décevant",
+      "pos": "ADJ",
+      "cefr": "A2",
+      "translations": ["enttäuschend"],
+      "frequency": 0.60
+    },
+    {
+      "term": "recommander",
+      "lemma": "recommander",
+      "pos": "VERB",
+      "cefr": "A2",
+      "translations": ["empfehlen"],
+      "frequency": 0.72
+    },
+    {
+      "term": "le prix",
+      "lemma": "prix",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["der Preis", "die Auszeichnung"],
+      "frequency": 0.80
+    },
+    {
+      "term": "le festival",
+      "lemma": "festival",
+      "pos": "NOUN",
+      "cefr": "A2",
+      "translations": ["das Festival", "die Filmfestspiele"],
+      "frequency": 0.70
+    }
+  ],
+  "phrases": [
+    {
+      "text": "Ce film a remporté la Palme d'or au Festival de Cannes.",
+      "translation": "Dieser Film hat die Goldene Palme beim Festival von Cannes gewonnen.",
+      "cefr": "A2"
+    },
+    {
+      "text": "Le réalisateur a tourné ce film en noir et blanc.",
+      "translation": "Der Regisseur hat diesen Film in Schwarz-Weiss gedreht.",
+      "cefr": "A2"
+    },
+    {
+      "text": "Les sous-titres aident les spectateurs à comprendre les dialogues.",
+      "translation": "Die Untertitel helfen den Zuschauern, die Dialoge zu verstehen.",
+      "cefr": "A2"
+    },
+    {
+      "text": "La bande-annonce donne envie de voir le film.",
+      "translation": "Der Trailer macht Lust, den Film zu sehen.",
+      "cefr": "A2"
+    },
+    {
+      "text": "L'actrice principale a reçu un prix pour son interprétation.",
+      "translation": "Die Hauptdarstellerin hat einen Preis für ihre Darstellung erhalten.",
+      "cefr": "A2"
+    },
+    {
+      "text": "Ce documentaire traite du changement climatique.",
+      "translation": "Dieser Dokumentarfilm behandelt den Klimawandel.",
+      "cefr": "A2"
+    },
+    {
+      "text": "Le scénario est inspiré d'une histoire vraie.",
+      "translation": "Das Drehbuch ist von einer wahren Geschichte inspiriert.",
+      "cefr": "A2"
+    },
+    {
+      "text": "La critique du journal était très positive.",
+      "translation": "Die Kritik der Zeitung war sehr positiv.",
+      "cefr": "B1"
+    },
+    {
+      "text": "Le tournage a duré six mois dans le sud de la France.",
+      "translation": "Die Dreharbeiten dauerten sechs Monate im Süden Frankreichs.",
+      "cefr": "B1"
+    },
+    {
+      "text": "Je recommande cette comédie, elle est vraiment drôle.",
+      "translation": "Ich empfehle diese Komödie, sie ist wirklich lustig.",
+      "cefr": "A2"
+    },
+    {
+      "text": "Les personnages de ce drame sont très réalistes.",
+      "translation": "Die Figuren dieses Dramas sind sehr realistisch.",
+      "cefr": "A2"
+    },
+    {
+      "text": "La première séance commence à quatorze heures.",
+      "translation": "Die erste Vorstellung beginnt um vierzehn Uhr.",
+      "cefr": "A2"
+    },
+    {
+      "text": "Ce film est à la fois émouvant et captivant.",
+      "translation": "Dieser Film ist gleichzeitig bewegend und fesselnd.",
+      "cefr": "A2"
+    },
+    {
+      "text": "Le cinéma du quartier projette des films en version originale.",
+      "translation": "Das Kino im Viertel zeigt Filme in der Originalfassung.",
+      "cefr": "A2"
+    },
+    {
+      "text": "Le genre préféré des Français est la comédie.",
+      "translation": "Das Lieblingsgenre der Franzosen ist die Komödie.",
+      "cefr": "A2"
+    },
+    {
+      "text": "L'écran géant offre une expérience immersive.",
+      "translation": "Die Grossleinwand bietet ein immersives Erlebnis.",
+      "cefr": "B1"
+    },
+    {
+      "text": "Les Frères Lumière ont inventé le cinématographe en 1895.",
+      "translation": "Die Gebrüder Lumière haben den Kinematographen 1895 erfunden.",
+      "cefr": "A2"
+    },
+    {
+      "text": "La Nouvelle Vague a révolutionné le cinéma français dans les années 1960.",
+      "translation": "Die Nouvelle Vague hat das französische Kino in den 1960er Jahren revolutioniert.",
+      "cefr": "B1"
+    }
+  ],
+  "grammar": {
+    "topic": "Le passé composé (das Perfekt)",
+    "content": "Das passé composé ist die wichtigste Vergangenheitsform im gesprochenen Französisch. Es entspricht dem deutschen Perfekt.\n\nBildung: Hilfsverb (avoir oder être) im Präsens + Partizip Perfekt (participe passé)\n\n1. Mit avoir (die meisten Verben):\n   j'ai regardé       ich habe geschaut\n   tu as regardé      du hast geschaut\n   il/elle a regardé  er/sie hat geschaut\n   nous avons regardé wir haben geschaut\n   vous avez regardé  ihr habt geschaut\n   ils/elles ont regardé  sie haben geschaut\n\n2. Mit être (Bewegungs- und reflexive Verben):\n   je suis allé(e)        ich bin gegangen\n   tu es allé(e)          du bist gegangen\n   il est allé / elle est allée   er/sie ist gegangen\n   nous sommes allé(e)s   wir sind gegangen\n   vous êtes allé(e)(s)   ihr seid gegangen\n   ils sont allés / elles sont allées   sie sind gegangen\n\n   Wichtig: Bei être passt sich das Partizip in Geschlecht und Zahl an das Subjekt an!\n\nPartizip-Bildung:\n   -er Verben: -é    (regarder → regardé)\n   -ir Verben: -i    (finir → fini)\n   -re Verben: -u    (attendre → attendu)\n\nHäufige unregelmässige Partizipien:\n   avoir → eu       être → été       faire → fait\n   voir → vu        prendre → pris   mettre → mis\n   dire → dit       écrire → écrit   lire → lu\n\nBeispiele:\n   J'ai vu un film émouvant hier soir.\n   (Ich habe gestern Abend einen bewegenden Film gesehen.)\n\n   Elle est allée au cinéma avec ses amis.\n   (Sie ist mit ihren Freunden ins Kino gegangen.)\n\n   Le réalisateur a tourné ce film en France.\n   (Der Regisseur hat diesen Film in Frankreich gedreht.)\n\n   Nous avons recommandé cette comédie à tout le monde.\n   (Wir haben diese Komödie allen empfohlen.)\n\nAchtung — typische Fehler:\n   • Avoir/être verwechseln: \"J'ai allé\" ist FALSCH → \"Je suis allé\"\n   • Angleichung vergessen: \"Elle est allé\" ist FALSCH → \"Elle est allée\"\n   • Unregelmässiges Partizip nicht kennen: \"J'ai voyé\" ist FALSCH → \"J'ai vu\""
+  },
+  "reading": {
+    "passage": "Le cinéma français est célèbre dans le monde entier. Depuis l'invention du cinématographe par les Frères Lumière en 1895, la France a joué un rôle central dans l'histoire du septième art.\n\nDans les années 1960, un groupe de jeunes réalisateurs a créé la Nouvelle Vague. François Truffaut, Jean-Luc Godard et Agnès Varda ont révolutionné la façon de faire des films. Ils ont utilisé des caméras légères, tourné dans les rues de Paris et raconté des histoires personnelles. Leurs films étaient différents du cinéma traditionnel : plus libres, plus proches de la vie réelle.\n\nAujourd'hui, le Festival de Cannes est le plus important festival de cinéma au monde. Chaque année en mai, des réalisateurs de tous les pays présentent leurs films sur la Croisette. La Palme d'or, le prix principal, est une récompense très prestigieuse. Des films comme \"Parasite\" de Bong Joon-ho (2019) ou \"Anatomie d'une chute\" de Justine Triet (2023) ont remporté ce prix.\n\nLe cinéma français produit environ 200 films par an. Les comédies sont le genre le plus populaire auprès du public français. Mais les drames et les documentaires reçoivent souvent les meilleures critiques. Les spectateurs français apprécient aussi les films en version originale avec sous-titres, surtout dans les grandes villes.\n\nLe cinéma reste un art vivant en France. Les petits cinémas de quartier existent toujours à côté des grands multiplexes. Pour beaucoup de Français, aller au cinéma est une sortie culturelle importante, pas seulement un divertissement.",
+    "questions": [
+      "Warum wird die Nouvelle Vague als revolutionär beschrieben? Nennen Sie zwei konkrete Veränderungen, die im Text erwähnt werden.",
+      "Was bedeutet der Ausdruck \"le septième art\" im Kontext des ersten Absatzes? Warum wird dieser Begriff für das Kino verwendet?",
+      "Der Text nennt zwei Palme-d'or-Gewinner aus verschiedenen Ländern. Was zeigt dies über die Bedeutung des Festivals von Cannes?",
+      "Welcher Zusammenhang besteht laut Text zwischen der Beliebtheit eines Filmgenres beim Publikum und der Qualität der Kritiken?",
+      "Am Ende des Textes werden kleine Quartierskinos und grosse Multiplexe nebeneinander erwähnt. Was sagt dies über die Rolle des Kinos in der französischen Kultur aus?"
+    ]
+  },
+  "exercises": {
+    "vocab_matching": {
+      "items": [
+        {"number": 1, "term": "le réalisateur", "translation": "der Regisseur"},
+        {"number": 2, "term": "le scénario", "translation": "das Drehbuch"},
+        {"number": 3, "term": "la scène", "translation": "die Szene"},
+        {"number": 4, "term": "le personnage", "translation": "die Figur"},
+        {"number": 5, "term": "l'écran", "translation": "die Leinwand"},
+        {"number": 6, "term": "la bande-annonce", "translation": "der Trailer"},
+        {"number": 7, "term": "le sous-titre", "translation": "der Untertitel"},
+        {"number": 8, "term": "la séance", "translation": "die Vorstellung"},
+        {"number": 9, "term": "le tournage", "translation": "die Dreharbeiten"},
+        {"number": 10, "term": "la critique", "translation": "die Kritik"}
+      ]
+    },
+    "fill_blanks": {
+      "items": [
+        {"number": 1, "sentence": "Ce ______ a remporté la Palme d'or à Cannes.", "target": "film"},
+        {"number": 2, "sentence": "Le ______ a tourné ce film en noir et blanc.", "target": "réalisateur"},
+        {"number": 3, "sentence": "Les ______ aident à comprendre les dialogues.", "target": "sous-titres"},
+        {"number": 4, "sentence": "La ______ donne envie de voir le film.", "target": "bande-annonce"},
+        {"number": 5, "sentence": "Le ______ est inspiré d'une histoire vraie.", "target": "scénario"},
+        {"number": 6, "sentence": "Je ______ cette comédie, elle est vraiment drôle.", "target": "recommande"},
+        {"number": 7, "sentence": "La première ______ commence à quatorze heures.", "target": "séance"},
+        {"number": 8, "sentence": "Ce film est à la fois émouvant et ______.", "target": "captivant"}
+      ],
+      "word_bank": ["film", "réalisateur", "sous-titres", "bande-annonce", "scénario", "recommande", "séance", "captivant", "spectateurs", "tournage"]
+    },
+    "synonyms": {
+      "items": [
+        {"number": 1, "term": "émouvant", "pos": "ADJ", "synonym": "touchant", "antonym": "indifférent"},
+        {"number": 2, "term": "captivant", "pos": "ADJ", "synonym": "passionnant", "antonym": "ennuyeux"},
+        {"number": 3, "term": "décevant", "pos": "ADJ", "synonym": "frustrant", "antonym": "satisfaisant"},
+        {"number": 4, "term": "recommander", "pos": "VERB", "synonym": "conseiller", "antonym": "déconseiller"},
+        {"number": 5, "term": "célèbre", "pos": "ADJ", "synonym": "connu", "antonym": "inconnu"},
+        {"number": 6, "term": "tourner", "pos": "VERB", "synonym": "filmer", "antonym": ""}
+      ]
+    },
+    "translation": {
+      "items": [
+        {"number": 1, "source": "Ce film a remporté la Palme d'or au Festival de Cannes."},
+        {"number": 2, "source": "Le réalisateur a tourné ce film en noir et blanc."},
+        {"number": 3, "source": "La bande-annonce donne envie de voir le film."},
+        {"number": 4, "source": "Le scénario est inspiré d'une histoire vraie."},
+        {"number": 5, "source": "Je recommande cette comédie, elle est vraiment drôle."},
+        {"number": 6, "source": "Les personnages de ce drame sont très réalistes."}
+      ]
+    },
+    "creative_writing": {
+      "prompt": "Schreiben Sie einen kurzen Absatz (6–8 Sätze) auf Französisch über einen Kinobesuch. Verwenden Sie mindestens 5 der folgenden Wörter und benutzen Sie das passé composé.",
+      "vocab_required": ["le cinéma", "le film", "la séance", "l'écran", "le spectateur", "recommander", "émouvant"]
+    },
+    "drawing_task": {
+      "prompt": "Zeichnen Sie eine Szene in einem Kino. Beschriften Sie mindestens 6 Gegenstände oder Personen auf Französisch (z.B. l'écran, le spectateur, le siège, le pop-corn, la sortie, la caisse)."
+    }
+  }
+}

--- a/src/langwich/generator.py
+++ b/src/langwich/generator.py
@@ -177,7 +177,13 @@ class WorksheetGenerator:
         for step in self.path.steps:
             exercise_cls = EXERCISE_REGISTRY.get(step.exercise_type)
             if exercise_cls is None:
-                logger.warning("Unknown exercise type: %s", step.exercise_type)
+                implemented = sorted(e.value for e in EXERCISE_REGISTRY)
+                logger.warning(
+                    "Exercise type '%s' is not yet implemented and will be skipped. "
+                    "Implemented types: %s",
+                    step.exercise_type.value,
+                    ", ".join(implemented),
+                )
                 continue
 
             # Use the partitioned phrase pool for text exercises, full set otherwise

--- a/src/langwich/import_data.py
+++ b/src/langwich/import_data.py
@@ -5,12 +5,15 @@ acts as the NLP engine: it generates domain-relevant vocabulary, translations,
 CEFR levels, and example phrases directly.  This module imports that structured
 data into the per-domain SQLite database so the worksheet generator can use it.
 
+See ``examples/film_de_fr.json`` for a complete working example.
+
 Expected JSON format
 ────────────────────
 {
   "domain": "railway-operations",
   "source_lang": "en",
   "target_lang": "de",
+
   "vocabulary": [
     {
       "term": "platform",
@@ -21,14 +24,45 @@ Expected JSON format
       "frequency": 0.85
     }
   ],
+
   "phrases": [
     {
       "text": "The train departs from platform 3.",
       "translation": "Der Zug fährt von Gleis 3 ab.",
       "cefr": "A2"
     }
-  ]
+  ],
+
+  "grammar": {
+    "topic": "Present Tense",
+    "content": "Complete grammar explanation — rules, tables, examples.
+                Rendered directly onto the PDF grammar page."
+  },
+
+  "reading": {
+    "passage": "Coherent multi-paragraph reading text in the target language.",
+    "questions": ["Comprehension question 1", "...up to 5 questions"]
+  },
+
+  "exercises": {
+    "vocab_matching": { "items": [{"number": 1, "term": "...", "translation": "..."}] },
+    "fill_blanks":    { "items": [{"number": 1, "sentence": "...", "target": "..."}],
+                        "word_bank": ["word1", "word2"] },
+    "synonyms":       { "items": [{"number": 1, "term": "...", "pos": "ADJ",
+                                    "synonym": "...", "antonym": "..."}] },
+    "translation":    { "items": [{"number": 1, "source": "Sentence to translate."}] },
+    "creative_writing": { "prompt": "Writing prompt text",
+                          "vocab_required": ["word1", "word2"] },
+    "text_summary":   { "passage": "Text for the student to summarise." },
+    "youtube_task":   { "video_url": "https://...",
+                        "questions": ["Question about the video"] },
+    "drawing_task":   { "prompt": "Draw a scene showing..." }
+  }
 }
+
+The ``grammar``, ``reading``, and ``exercises`` sections are optional but
+strongly recommended.  Without them, the worksheet will use low-quality
+fallbacks or skip content entirely.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
LLM agents outside Claude Code failed to generate worksheets because:
- README showed only vocabulary/phrases, not grammar/reading/exercises
- All 35 exercise types were listed as available when only 9 are implemented
- No complete example JSON existed anywhere in the repo
- import_data.py docstring only showed the minimal schema

Changes:
- Add examples/film_de_fr.json — complete working example with all sections
- Rewrite README JSON section with full schema and field reference
- Split exercise table into "Implemented (9)" and "Planned (26)"
- Update CLAUDE.md to surface slash command docs for external LLM agents
- Update import_data.py docstring with complete schema including exercises
- Improve generator.py warning to list implemented types when skipping

https://claude.ai/code/session_0173NL6u3KJasXCBu7btot25